### PR TITLE
feat: z-score width, awards, postseason overlays for WAR charts

### DIFF
--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -201,12 +201,16 @@ generate_franchise_war_plot <- function(
     player_type_label, 
     start_year = 1901, 
     top_n = 5,
-    position_filter = NULL  # NULL = all, or "C", "1B", "2B", "SS", "3B", "OF", "SP", "RP"
+    position_filter = NULL,  # NULL = all, or "C", "1B", "2B", "SS", "3B", "OF", "SP", "RP"
+    variable_width = FALSE,  # Z-score line width
+    pos_year_stats = NULL,   # Required if variable_width = TRUE
+    show_awards = FALSE,
+    award_data = NULL,       # Required if show_awards = TRUE
+    show_postseason = FALSE
 ) {
   
  # For SP/RP filtering, we need to classify pitchers first
   if (!is.null(position_filter) && position_filter %in% c("SP", "RP")) {
-    # Get SP vs RP classification from Lahman (career-wide for simplicity)
     pitcher_type <- Lahman::Pitching %>%
       group_by(playerID) %>%
       summarise(
@@ -217,19 +221,17 @@ generate_franchise_war_plot <- function(
       mutate(pitcher_role = if_else(total_GS > total_G * 0.5, "SP", "RP")) %>%
       select(playerID, pitcher_role)
     
-    # Join and filter
     war_data <- war_data %>%
       left_join(pitcher_type, by = c("player_ID" = "playerID")) %>%
       filter(pitcher_role == position_filter)
     
     player_type_label <- paste0(player_type_label, " (", position_filter, ")")
   } else if (!is.null(position_filter)) {
-    # Standard position filter
     war_data <- war_data %>% filter(primary_pos == position_filter)
     player_type_label <- paste0(player_type_label, " (", position_filter, ")")
   }
   
-  # Determine primary position per player (the one with most WAR)
+  # Determine primary position per player
   player_positions <- war_data %>%
     filter(!is.na(WAR)) %>%
     group_by(player_ID, primary_pos) %>%
@@ -238,7 +240,6 @@ generate_franchise_war_plot <- function(
     slice_max(pos_WAR, n = 1, with_ties = FALSE) %>%
     select(player_ID, primary_pos)
   
-  # Apply franchise mapping and aggregate by player-franchise-year
   WAR_clean <- war_data %>%
     mutate(franchise = franchise_map(team_ID)) %>%
     filter(!is.na(franchise), !is.na(WAR)) %>%
@@ -248,7 +249,6 @@ generate_franchise_war_plot <- function(
     left_join(divisions, by = "franchise") %>%
     mutate(division_full = paste(league, division))
   
-  # Calculate cumulative WAR by player-franchise
   WAR_cum <- WAR_clean %>%
     group_by(player_ID, franchise) %>%
     arrange(year_ID) %>%
@@ -259,7 +259,6 @@ generate_franchise_war_plot <- function(
     ) %>%
     ungroup()
   
-  # Identify top N players per franchise (within period, 2+ years)
   top_players <- WAR_cum %>%
     filter(year_ID >= start_year) %>%
     group_by(franchise, player_ID) %>%
@@ -279,7 +278,6 @@ generate_franchise_war_plot <- function(
     left_join(top_players, by = c("franchise", "player_ID")) %>%
     mutate(is_top = replace_na(is_top, FALSE))
   
-  # Prepare plot data - only add position to label if showing multiple positions
   plot_data <- WAR_cum %>%
     filter(year_ID >= start_year) %>%
     mutate(name_label = if (is.null(position_filter)) {
@@ -288,7 +286,7 @@ generate_franchise_war_plot <- function(
       name_common
     })
   
-  # Adjust x-axis breaks based on era
+  # x-axis breaks
   if (start_year >= 1990) {
     x_breaks <- seq(2000, 2020, 10)
   } else if (start_year >= 1960) {
@@ -297,30 +295,144 @@ generate_franchise_war_plot <- function(
     x_breaks <- seq(1920, 2020, 40)
   }
   
-  # Create the faceted plot
-  p <- ggplot(filter(plot_data, is_top), aes(x = year_ID, y = cumWAR_franchise)) +
-    geom_line(aes(group = player_ID, color = franchise), linewidth = 1) +
-    geom_label_repel(
-      data = filter(plot_data, is_top & year_ID == max_year),
-      aes(label = name_label, color = franchise),
-      size = 2.2,
-      fill = alpha("white", 0.85),
-      label.size = 0,
-      segment.size = 0.3,
-      segment.alpha = 0.5,
-      max.overlaps = 15,
-      nudge_y = 3,
-      box.padding = 0.15,
-      point.padding = 0.1,
-      min.segment.length = 0.2
+  # --- Z-score segments for variable width ---
+  top_segments <- NULL
+  if (variable_width && !is.null(pos_year_stats)) {
+    zscore_pos <- if (!is.null(position_filter) && position_filter %in% 
+                      c("C", "1B", "2B", "SS", "3B", "OF", "SP", "RP")) {
+      position_filter
+    } else {
+      NULL  # Can't z-score mixed positions
+    }
+    
+    if (!is.null(zscore_pos)) {
+      pos_stats_filtered <- pos_year_stats %>% filter(position == zscore_pos)
+      
+      top_segments <- plot_data %>%
+        filter(is_top) %>%
+        left_join(pos_stats_filtered, by = c("year_ID")) %>%
+        mutate(
+          war_zscore = (WAR - mean_WAR) / sd_WAR,
+          war_zscore_clamped = pmin(pmax(war_zscore, 0), 4)
+        ) %>%
+        group_by(player_ID, franchise) %>%
+        arrange(year_ID) %>%
+        mutate(
+          next_year = lead(year_ID),
+          next_cumWAR = lead(cumWAR_franchise),
+          width_z = lead(war_zscore_clamped)
+        ) %>%
+        filter(!is.na(next_year), !is.na(width_z)) %>%
+        ungroup()
+    }
+  }
+  
+  # --- Build the plot ---
+  top_plot_data <- filter(plot_data, is_top)
+  
+  p <- ggplot(top_plot_data, aes(x = year_ID, y = cumWAR_franchise))
+  
+  if (!is.null(top_segments) && nrow(top_segments) > 0) {
+    p <- p + geom_segment(
+      data = top_segments,
+      aes(x = year_ID, xend = next_year,
+          y = cumWAR_franchise, yend = next_cumWAR,
+          linewidth = width_z, color = franchise),
+      lineend = "round", linejoin = "round"
     ) +
-    scale_color_manual(values = primary_colors) +
+    scale_linewidth_continuous(
+      name = "Positional Dominance",
+      range = c(0.3, 4),
+      breaks = c(0, 1, 2, 3, 4),
+      labels = c("Avg", "+1σ", "+2σ", "+3σ", "+4σ"),
+      guide = guide_legend(override.aes = list(color = "gray30"))
+    )
+  } else {
+    p <- p + geom_line(
+      data = top_plot_data,
+      aes(group = player_ID, color = franchise),
+      linewidth = 1
+    )
+  }
+  
+  # Labels
+  p <- p + geom_label_repel(
+    data = filter(top_plot_data, year_ID == max_year),
+    aes(label = name_label, color = franchise),
+    size = 2.2, fill = alpha("white", 0.85), label.size = 0,
+    segment.size = 0.3, segment.alpha = 0.5,
+    max.overlaps = 15, nudge_y = 3,
+    box.padding = 0.15, point.padding = 0.1,
+    min.segment.length = 0.2
+  )
+  
+  # Award markers
+  if (show_awards && !is.null(award_data)) {
+    award_markers <- top_plot_data %>%
+      filter(is_top) %>%
+      inner_join(award_data, by = c("player_ID" = "playerID", "year_ID" = "yearID"),
+                 relationship = "many-to-many") %>%
+      filter(award %in% c("MVP", "CYA", "AS")) %>%
+      mutate(award = factor(award, levels = c("MVP", "CYA", "AS")))
+    
+    if (nrow(award_markers) > 0) {
+      p <- p + geom_point(
+        data = award_markers,
+        aes(shape = award, size = award, fill = award),
+        color = "black", stroke = 0.5
+      ) +
+      scale_shape_manual(name = "Awards",
+        values = c("MVP" = 23, "CYA" = 24, "AS" = 21)) +
+      scale_size_manual(name = "Awards",
+        values = c("MVP" = 3, "CYA" = 3, "AS" = 1.2)) +
+      scale_fill_manual(name = "Awards",
+        values = c("MVP" = "gold", "CYA" = "gold", "AS" = "gray80"))
+    }
+  }
+  
+  # Postseason vlines per franchise facet
+  if (show_postseason) {
+    all_postseason <- bind_rows(
+      lapply(unique(WAR_clean$franchise), function(fc) {
+        ps <- get_postseason_data(fc)
+        if (nrow(ps) > 0) {
+          ps %>%
+            mutate(franchise = fc) %>%
+            left_join(divisions, by = "franchise") %>%
+            filter(yearID >= start_year)
+        }
+      })
+    )
+    
+    if (nrow(all_postseason) > 0) {
+      p <- p + geom_vline(
+        data = all_postseason,
+        aes(xintercept = yearID, linetype = achievement),
+        alpha = 0.3, linewidth = 0.3
+      ) +
+      scale_linetype_manual(name = "Postseason",
+        values = c("World Series" = "solid", "Pennant/LCS" = "dashed",
+                   "Division Series" = "dotted", "Wild Card" = "dotdash"))
+    }
+  }
+  
+  # Scales, facets, theme
+  subtitle_parts <- paste0("Top ", top_n, " per franchise")
+  if (!is.null(top_segments) && nrow(top_segments) > 0) {
+    subtitle_parts <- paste0(subtitle_parts, " | Line width = positional dominance (σ)")
+  }
+  
+  p <- p +
+    scale_color_manual(values = primary_colors, guide = "none") +
     scale_x_continuous(breaks = x_breaks) +
     ggh4x::facet_wrap2(~ reorder(franchise, div_order), ncol = 5, axes = "x") +
-    coord_cartesian(xlim = c(start_year, 2026), ylim = c(0, 175)) +  # Clip display, don't remove data
+    coord_cartesian(xlim = c(start_year, 2026), ylim = c(0, 175)) +
     theme_minimal() +
     theme(
-      legend.position = "none",
+      legend.position = "top",
+      legend.justification = "left",
+      legend.box = "horizontal",
+      legend.box.just = "left",
       panel.spacing.x = unit(1.2, "lines"),
       panel.spacing.y = unit(0.8, "lines"),
       strip.text = element_text(face = "bold", size = 9),
@@ -328,16 +440,22 @@ generate_franchise_war_plot <- function(
       axis.text.x = element_text(angle = 0),
       panel.grid.minor = element_blank()
     ) +
+    guides(
+      shape = guide_legend(order = 1),
+      size = guide_legend(order = 1),
+      fill = guide_legend(order = 1),
+      linetype = guide_legend(order = 2),
+      linewidth = guide_legend(order = 3)
+    ) +
     labs(
-      title = paste0("Cumulative WAR by Franchise — ", player_type_label, " (", start_year, "-Present)"),
-      subtitle = paste0("Top ", top_n, " per franchise highlighted"),
-      x = "Year",
-      y = "Cumulative WAR",
-      caption = "Source: Baseball Reference"
+      title = paste0("Cumulative WAR by Franchise — ", player_type_label,
+                     " (", start_year, "-Present)"),
+      subtitle = subtitle_parts,
+      x = "Year", y = "Cumulative WAR",
+      caption = "Source: Baseball Reference + Lahman"
     )
   
-  # Attach the top players data as an attribute for export
-  # Filter to start_year so CSV matches the era shown in plot
+  # Attach data for CSV export
   top_summary <- WAR_cum %>%
     filter(is_top, year_ID >= start_year) %>%
     group_by(franchise, player_ID, name_common, primary_pos) %>%
@@ -374,3 +492,169 @@ export_plot_data <- function(plot, filename) {
 ERAS <- c(1901, 1961, 1969, 1977, 1993, 1998)
 POSITIONS <- c("All", "C", "1B", "2B", "SS", "3B", "OF")
 PLAYER_TYPES <- c("batters", "pitchers", "combined")
+
+# =============================================================================
+# AWARD DATA (loaded once, reused by all views)
+# =============================================================================
+
+load_award_data <- function() {
+  awards_raw <- Lahman::AwardsPlayers %>%
+    filter(awardID %in% c("Most Valuable Player", "Cy Young Award")) %>%
+    mutate(award = case_when(
+      awardID == "Most Valuable Player" ~ "MVP",
+      awardID == "Cy Young Award" ~ "CYA"
+    )) %>%
+    select(playerID, yearID, award)
+  
+  allstars <- Lahman::AllstarFull %>%
+    distinct(playerID, yearID) %>%
+    mutate(award = "AS")
+  
+  bind_rows(awards_raw, allstars)
+}
+
+# =============================================================================
+# LEAGUE-WIDE Z-SCORE STATS (loaded once, reused by all views)
+# =============================================================================
+
+compute_position_year_stats <- function(war_batting, war_pitching) {
+  message("Computing league-wide position-year WAR distributions...")
+  
+  # League-wide pitcher classification
+  league_pitcher_type <- Lahman::Pitching %>%
+    group_by(playerID) %>%
+    summarise(
+      total_G = sum(G, na.rm = TRUE),
+      total_GS = sum(GS, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    mutate(pitcher_role = if_else(total_GS > total_G * 0.5, "SP", "RP")) %>%
+    select(playerID, pitcher_role)
+  
+  # League-wide DH detection
+  league_dh_players <- Lahman::Appearances %>%
+    group_by(playerID) %>%
+    summarise(
+      dh_games = sum(G_dh, na.rm = TRUE),
+      field_games = sum(G_defense, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    filter(dh_games > field_games * 0.5) %>%
+    mutate(is_primary_dh = TRUE) %>%
+    select(playerID, is_primary_dh)
+  
+  common_cols <- c("year_ID", "player_ID", "name_common", "team_ID", "WAR", "primary_pos")
+  league_war <- bind_rows(
+    war_batting %>% select(all_of(common_cols)),
+    war_pitching %>% select(all_of(common_cols))
+  ) %>%
+    filter(!is.na(WAR), !is.na(primary_pos)) %>%
+    left_join(league_dh_players, by = c("player_ID" = "playerID")) %>%
+    left_join(league_pitcher_type, by = c("player_ID" = "playerID")) %>%
+    mutate(position = case_when(
+      !is.na(is_primary_dh) ~ "DH",
+      primary_pos %in% c("LF", "CF", "RF") ~ "OF",
+      primary_pos == "P" & pitcher_role == "RP" ~ "RP",
+      primary_pos == "P" ~ "SP",
+      TRUE ~ primary_pos
+    )) %>%
+    filter(position %in% c("C", "1B", "2B", "SS", "3B", "OF", "DH", "SP", "RP")) %>%
+    group_by(player_ID, position, year_ID) %>%
+    summarise(WAR = sum(WAR, na.rm = TRUE), .groups = "drop")
+  
+  pos_year_stats <- league_war %>%
+    group_by(position, year_ID) %>%
+    summarise(
+      mean_WAR = mean(WAR, na.rm = TRUE),
+      sd_WAR = sd(WAR, na.rm = TRUE),
+      n_players = n(),
+      .groups = "drop"
+    ) %>%
+    mutate(sd_WAR = pmax(sd_WAR, 0.5))
+  
+  message(sprintf("  %d position-years computed", nrow(pos_year_stats)))
+  pos_year_stats
+}
+
+# =============================================================================
+# POSTSEASON DATA HELPER
+# =============================================================================
+
+# Lahman team code mapping (reverse of franchise_map)
+LAHMAN_CODES <- list(
+  "NYY" = c("NYA"), "LAD" = c("LAN", "BRO"), "SFG" = c("SFN", "NYG"),
+  "ATL" = c("ATL", "MLN", "BSN"), "BAL" = c("BAL", "SLA", "MLA"),
+  "MIN" = c("MIN", "WS1", "WS2"), "OAK" = c("OAK", "PHA", "KCA"),
+  "TEX" = c("TEX", "WS2"), "MIL" = c("MIL", "SEA"),
+  "WSN" = c("WAS", "MON"), "CHC" = c("CHN"), "CIN" = c("CIN"),
+  "STL" = c("SLN"), "PIT" = c("PIT"), "PHI" = c("PHI"),
+  "BOS" = c("BOS"), "CLE" = c("CLE"), "DET" = c("DET"),
+  "CHW" = c("CHA"), "SEA" = c("SEA"), "TBR" = c("TBA"),
+  "TOR" = c("TOR"), "HOU" = c("HOU"), "LAA" = c("ANA", "CAL", "LAA"),
+  "KCR" = c("KCA"), "ARI" = c("ARI"), "COL" = c("COL"),
+  "SDP" = c("SDN"), "MIA" = c("FLO", "MIA"), "NYM" = c("NYN")
+)
+
+get_postseason_data <- function(team_code) {
+  lahman_codes <- LAHMAN_CODES[[team_code]]
+  if (is.null(lahman_codes)) lahman_codes <- team_code
+  
+  Lahman::SeriesPost %>%
+    filter(teamIDwinner %in% lahman_codes) %>%
+    mutate(achievement = case_when(
+      round == "WS" ~ "World Series",
+      round %in% c("CS", "ALCS", "NLCS") ~ "Pennant/LCS",
+      grepl("DS|DIV", round) ~ "Division Series",
+      grepl("WC", round) ~ "Wild Card",
+      TRUE ~ "Pennant/LCS"
+    )) %>%
+    distinct(yearID, achievement) %>%
+    mutate(achievement = factor(achievement,
+      levels = c("World Series", "Pennant/LCS", "Division Series", "Wild Card"))) %>%
+    group_by(yearID) %>%
+    slice_min(achievement, n = 1) %>%
+    ungroup()
+}
+
+# =============================================================================
+# OVERLAY GENERATION HELPER
+# =============================================================================
+
+# Save a transparent overlay PNG that is pixel-aligned with the base plot.
+# Builds an overlay plot using the same scales/facets/coords/dimensions,
+# but with transparent backgrounds and invisible text (preserving spacing).
+save_overlay_png <- function(overlay_layers, base_plot, filename,
+                             width, height, dpi = 150) {
+  # Extract the base plot's scales, facet, coord, and theme
+  p_overlay <- base_plot
+  
+  # Remove all existing layers from the base
+  p_overlay$layers <- list()
+  
+  # Add only the overlay layers
+  for (layer in overlay_layers) {
+    p_overlay <- p_overlay + layer
+  }
+  
+  # Make everything transparent except the overlay marks
+  p_overlay <- p_overlay +
+    theme(
+      panel.background = element_rect(fill = "transparent", color = NA),
+      plot.background = element_rect(fill = "transparent", color = NA),
+      panel.grid.major = element_blank(),
+      panel.grid.minor = element_blank(),
+      axis.text = element_text(color = "transparent"),
+      axis.title = element_text(color = "transparent"),
+      axis.ticks = element_line(color = "transparent"),
+      strip.text = element_text(color = "transparent"),
+      strip.background = element_rect(fill = "transparent", color = NA),
+      plot.title = element_text(color = "transparent"),
+      plot.subtitle = element_text(color = "transparent"),
+      plot.caption = element_text(color = "transparent"),
+      legend.position = "none"
+    )
+  
+  ggsave(filename, plot = p_overlay, width = width, height = height,
+         dpi = dpi, bg = "transparent")
+  message(sprintf("  Overlay saved: %s", filename))
+}

--- a/generate_all_plots.R
+++ b/generate_all_plots.R
@@ -1,6 +1,6 @@
 # generate_all_plots.R
 # Batch generation of all WAR plots for GH Pages
-# Run this after you're happy with the look/feel in franchise_war_analysis.R
+# Generates base images (constant + z-score width) and transparent overlays
 
 source("franchise_war_functions.R")
 
@@ -9,15 +9,13 @@ source("franchise_war_functions.R")
 # =============================================================================
 
 OUTPUT_DIR <- "docs/plots"
+DATA_DIR <- "docs/data"
 dir.create(OUTPUT_DIR, showWarnings = FALSE, recursive = TRUE)
+dir.create(DATA_DIR, showWarnings = FALSE, recursive = TRUE)
 
-# Eras to generate
 ERAS <- c(1901, 1961, 1969, 1977, 1993, 1998)
 
-# Single unified position list (replaces separate type + position dropdowns)
-# Format: display_name = list(data_source, position_filter)
-#   data_source: "batting", "pitching", or "combined"
-#   position_filter: NULL for all, or specific position code
+# Position config: data source + filter
 POSITIONS <- list(
   "all" = list(source = "combined", filter = NULL),
   "batters" = list(source = "batting", filter = NULL),
@@ -31,6 +29,10 @@ POSITIONS <- list(
   "SP" = list(source = "pitching", filter = "SP"),
   "RP" = list(source = "pitching", filter = "RP")
 )
+
+PLOT_WIDTH <- 20
+PLOT_HEIGHT <- 24
+PLOT_DPI <- 150
 
 # =============================================================================
 # LOAD DATA
@@ -47,55 +49,85 @@ WAR_combined <- bind_rows(
   WAR_pitch %>% select(all_of(common_cols))
 )
 
-# Create data output directory
-DATA_DIR <- "docs/data"
-dir.create(DATA_DIR, showWarnings = FALSE, recursive = TRUE)
+message("=== Loading shared data (z-scores, awards) ===")
+pos_year_stats <- compute_position_year_stats(WAR_bat, WAR_pitch)
+award_data <- load_award_data()
 
 # =============================================================================
 # GENERATE ALL PLOTS
 # =============================================================================
 
-total_plots <- length(ERAS) * length(POSITIONS)
-current_plot <- 0
+# For each position × era, generate:
+#   1. Base constant-width PNG
+#   2. Base z-score-width PNG (single positions only)
+#   3. Awards overlay (transparent)
+#   4. Postseason overlay (transparent)
+#   5. CSV data export
 
-message(sprintf("\n=== Generating %d plots ===\n", total_plots))
+n_positions <- length(POSITIONS)
+n_eras <- length(ERAS)
+current <- 0
+
+message(sprintf("\n=== Generating plots for %d positions × %d eras ===\n", n_positions, n_eras))
 
 for (era in ERAS) {
   for (pos_name in names(POSITIONS)) {
-    current_plot <- current_plot + 1
+    current <- current + 1
     
     pos_config <- POSITIONS[[pos_name]]
     pos_filter <- pos_config$filter
+    can_zscore <- !is.null(pos_filter) && pos_filter %in% c("C","1B","2B","SS","3B","OF","SP","RP")
     
-    # Select appropriate data source
     war_source <- switch(pos_config$source,
-      "batting" = WAR_bat,
-      "pitching" = WAR_pitch,
-      "combined" = WAR_combined
-    )
-    
-    # Label for plot title
+      "batting" = WAR_bat, "pitching" = WAR_pitch, "combined" = WAR_combined)
     type_label <- switch(pos_config$source,
-      "batting" = "Position Players",
-      "pitching" = "Pitchers",
-      "combined" = "All Players"
-    )
+      "batting" = "Position Players", "pitching" = "Pitchers", "combined" = "All Players")
     
     base_name <- sprintf("%s_%d", tolower(pos_name), era)
-    png_file <- sprintf("%s/%s.png", OUTPUT_DIR, base_name)
-    csv_file <- sprintf("%s/%s.csv", DATA_DIR, base_name)
-    message(sprintf("[%d/%d] %s", current_plot, total_plots, png_file))
+    message(sprintf("[%d/%d] %s", current, n_positions * n_eras, base_name))
     
-    p <- generate_franchise_war_plot(
-      war_source, 
-      type_label, 
-      start_year = era, 
-      position_filter = pos_filter
-    )
-    ggsave(png_file, plot = p, width = 20, height = 24, units = "in", dpi = 150)
-    export_plot_data(p, csv_file)
+    # --- 1. Constant-width base ---
+    p_const <- generate_franchise_war_plot(
+      war_source, type_label, start_year = era, position_filter = pos_filter)
+    ggsave(sprintf("%s/%s.png", OUTPUT_DIR, base_name),
+           plot = p_const, width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+    export_plot_data(p_const, sprintf("%s/%s.csv", DATA_DIR, base_name))
+    
+    # --- 2. Z-score-width base (single positions only) ---
+    if (can_zscore) {
+      p_zscore <- generate_franchise_war_plot(
+        war_source, type_label, start_year = era, position_filter = pos_filter,
+        variable_width = TRUE, pos_year_stats = pos_year_stats)
+      ggsave(sprintf("%s/%s_zscore.png", OUTPUT_DIR, base_name),
+             plot = p_zscore, width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+    }
+    
+    # --- 3. Awards overlay ---
+    p_awards <- generate_franchise_war_plot(
+      war_source, type_label, start_year = era, position_filter = pos_filter,
+      show_awards = TRUE, award_data = award_data)
+    award_layer <- p_awards$layers[sapply(p_awards$layers, function(l) {
+      inherits(l$geom, "GeomPoint")
+    })]
+    if (length(award_layer) > 0) {
+      save_overlay_png(award_layer, p_const,
+        sprintf("%s/%s_awards.png", OUTPUT_DIR, base_name),
+        width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+    }
+    
+    # --- 4. Postseason overlay ---
+    p_post <- generate_franchise_war_plot(
+      war_source, type_label, start_year = era, position_filter = pos_filter,
+      show_postseason = TRUE)
+    post_layer <- p_post$layers[sapply(p_post$layers, function(l) {
+      inherits(l$geom, "GeomVline")
+    })]
+    if (length(post_layer) > 0) {
+      save_overlay_png(post_layer, p_const,
+        sprintf("%s/%s_postseason.png", OUTPUT_DIR, base_name),
+        width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+    }
   }
 }
 
-message(sprintf("\n=== Done! Generated %d plots in %s ===", total_plots, OUTPUT_DIR))
-message(sprintf("Data tables exported to %s", DATA_DIR))
+message(sprintf("\n=== Done! Generated plots in %s ===", OUTPUT_DIR))

--- a/generate_team_breakdowns.R
+++ b/generate_team_breakdowns.R
@@ -1,6 +1,6 @@
 # generate_team_breakdowns.R
 # Batch generation of team position breakdown charts
-# Generates linear and log scale versions with postseason overlay
+# Generates: constant + z-score bases (× linear/log), plus overlays
 
 source("franchise_war_functions.R")
 source("team_position_breakdown.R")
@@ -12,108 +12,131 @@ source("team_position_breakdown.R")
 OUTPUT_DIR <- "docs/team_breakdowns"
 dir.create(OUTPUT_DIR, showWarnings = FALSE, recursive = TRUE)
 
-# All 30 MLB teams with full names
+PLOT_WIDTH <- 20
+PLOT_DPI <- 150
+
 TEAMS <- list(
   # AL East
-  "BAL" = "Baltimore Orioles",
-  "BOS" = "Boston Red Sox",
-  "NYY" = "New York Yankees",
-  "TBR" = "Tampa Bay Rays",
-  "TOR" = "Toronto Blue Jays",
+  "BAL" = "Baltimore Orioles", "BOS" = "Boston Red Sox",
+  "NYY" = "New York Yankees", "TBR" = "Tampa Bay Rays", "TOR" = "Toronto Blue Jays",
   # AL Central
-  "CHW" = "Chicago White Sox",
-  "CLE" = "Cleveland Guardians",
-  "DET" = "Detroit Tigers",
-  "KCR" = "Kansas City Royals",
-  "MIN" = "Minnesota Twins",
+  "CHW" = "Chicago White Sox", "CLE" = "Cleveland Guardians",
+  "DET" = "Detroit Tigers", "KCR" = "Kansas City Royals", "MIN" = "Minnesota Twins",
   # AL West
-  "HOU" = "Houston Astros",
-  "LAA" = "Los Angeles Angels",
-  "OAK" = "Oakland Athletics",
-  "SEA" = "Seattle Mariners",
-  "TEX" = "Texas Rangers",
+  "HOU" = "Houston Astros", "LAA" = "Los Angeles Angels",
+  "OAK" = "Oakland Athletics", "SEA" = "Seattle Mariners", "TEX" = "Texas Rangers",
   # NL East
-  "ATL" = "Atlanta Braves",
-  "MIA" = "Miami Marlins",
-  "NYM" = "New York Mets",
-  "PHI" = "Philadelphia Phillies",
-  "WSN" = "Washington Nationals",
+  "ATL" = "Atlanta Braves", "MIA" = "Miami Marlins",
+  "NYM" = "New York Mets", "PHI" = "Philadelphia Phillies", "WSN" = "Washington Nationals",
   # NL Central
-  "CHC" = "Chicago Cubs",
-  "CIN" = "Cincinnati Reds",
-  "MIL" = "Milwaukee Brewers",
-  "PIT" = "Pittsburgh Pirates",
-  "STL" = "St. Louis Cardinals",
+  "CHC" = "Chicago Cubs", "CIN" = "Cincinnati Reds",
+  "MIL" = "Milwaukee Brewers", "PIT" = "Pittsburgh Pirates", "STL" = "St. Louis Cardinals",
   # NL West
-  "ARI" = "Arizona Diamondbacks",
-  "COL" = "Colorado Rockies",
-  "LAD" = "Los Angeles Dodgers",
-  "SDP" = "San Diego Padres",
-  "SFG" = "San Francisco Giants"
+  "ARI" = "Arizona Diamondbacks", "COL" = "Colorado Rockies",
+  "LAD" = "Los Angeles Dodgers", "SDP" = "San Diego Padres", "SFG" = "San Francisco Giants"
 )
+
+# =============================================================================
+# LOAD SHARED DATA
+# =============================================================================
+
+message("=== Loading shared data ===")
+pos_year_stats <- compute_position_year_stats(WAR_bat, WAR_pitch)
+award_data <- load_award_data()
 
 # =============================================================================
 # BATCH GENERATE
 # =============================================================================
 
-# Generate two versions per team:
-# 1. Linear scale with postseason overlay (primary)
-# 2. Log scale with postseason overlay (for comparison)
+# Per team: 2 scales × 2 widths = 4 base PNGs + 2 award overlays + 2 postseason overlays = 8
+# 30 teams × 8 = 240 total
 
-total_plots <- length(TEAMS) * 2
-current_plot <- 0
+n_teams <- length(TEAMS)
+scales <- c("linear", "log")
+widths <- c("const", "zscore")
+current <- 0
+total <- n_teams * length(scales) * (length(widths) + 2)  # bases + overlays
 
-message(sprintf("\n=== Generating %d team breakdown plots ===\n", total_plots))
+message(sprintf("\n=== Generating ~%d team breakdown images ===\n", total))
 
 for (team_code in names(TEAMS)) {
   team_name <- TEAMS[[team_code]]
   
-  # --- Linear scale version ---
-  current_plot <- current_plot + 1
-  png_file <- sprintf("%s/%s_linear.png", OUTPUT_DIR, team_code)
-  message(sprintf("[%d/%d] %s (linear)", current_plot, total_plots, team_code))
-  
-  p <- generate_team_position_plot(
-    WAR_bat,
-    WAR_pitch,
-    team_code = team_code,
-    team_name = team_name,
-    show_postseason = TRUE,
-    log_scale = FALSE
-  )
-  
-  n_pos <- attr(p, "n_positions")
-  ggsave(
-    png_file, 
-    plot = p, 
-    width = 20, 
-    height = 3 * n_pos + 2,
-    units = "in",
-    dpi = 150
-  )
-  
-  # --- Log scale version ---
-  current_plot <- current_plot + 1
-  png_file <- sprintf("%s/%s_log.png", OUTPUT_DIR, team_code)
-  message(sprintf("[%d/%d] %s (log)", current_plot, total_plots, team_code))
-  
-  p <- generate_team_position_plot(
-    WAR_bat,
-    WAR_pitch,
-    team_code = team_code,
-    team_name = team_name,
-    show_postseason = TRUE,
-    log_scale = TRUE
-  )
-  
-  ggsave(
-    png_file, 
-    plot = p, 
-    width = 20, 
-    height = 3 * n_pos + 2,
-    units = "in",
-    dpi = 150
-  )
+  for (scale_name in scales) {
+    is_log <- scale_name == "log"
+    
+    for (width_name in widths) {
+      is_zscore <- width_name == "zscore"
+      current <- current + 1
+      
+      fname <- sprintf("%s/%s_%s_%s.png", OUTPUT_DIR, team_code, scale_name, width_name)
+      message(sprintf("[%d/%d] %s %s %s", current, total, team_code, scale_name, width_name))
+      
+      p <- generate_team_position_plot(
+        WAR_bat, WAR_pitch,
+        team_code = team_code, team_name = team_name,
+        show_postseason = TRUE,
+        log_scale = is_log,
+        variable_width = is_zscore,
+        pos_year_stats = if (is_zscore) pos_year_stats else NULL
+      )
+      
+      n_pos <- attr(p, "n_positions")
+      plot_height <- 3 * n_pos + 2
+      ggsave(fname, plot = p, width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
+    }
+    
+    # --- Award overlay (one per scale) ---
+    current <- current + 1
+    message(sprintf("[%d/%d] %s %s awards overlay", current, total, team_code, scale_name))
+    
+    p_awards <- generate_team_position_plot(
+      WAR_bat, WAR_pitch,
+      team_code = team_code, team_name = team_name,
+      log_scale = is_log,
+      show_awards = TRUE, award_data = award_data
+    )
+    
+    n_pos <- attr(p_awards, "n_positions")
+    plot_height <- 3 * n_pos + 2
+    
+    award_layers <- p_awards$layers[sapply(p_awards$layers, function(l) {
+      inherits(l$geom, "GeomPoint")
+    })]
+    
+    # Use the constant-width base as reference for overlay alignment
+    p_ref <- generate_team_position_plot(
+      WAR_bat, WAR_pitch,
+      team_code = team_code, team_name = team_name,
+      show_postseason = TRUE, log_scale = is_log
+    )
+    
+    if (length(award_layers) > 0) {
+      save_overlay_png(award_layers, p_ref,
+        sprintf("%s/%s_%s_awards.png", OUTPUT_DIR, team_code, scale_name),
+        width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
+    }
+    
+    # --- Postseason overlay (one per scale) ---
+    current <- current + 1
+    message(sprintf("[%d/%d] %s %s postseason overlay", current, total, team_code, scale_name))
+    
+    p_post <- generate_team_position_plot(
+      WAR_bat, WAR_pitch,
+      team_code = team_code, team_name = team_name,
+      show_postseason = TRUE, log_scale = is_log
+    )
+    
+    post_layers <- p_post$layers[sapply(p_post$layers, function(l) {
+      inherits(l$geom, "GeomVline")
+    })]
+    
+    if (length(post_layers) > 0) {
+      save_overlay_png(post_layers, p_ref,
+        sprintf("%s/%s_%s_postseason.png", OUTPUT_DIR, team_code, scale_name),
+        width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
+    }
+  }
 }
 
-message(sprintf("\n=== Done! Generated %d plots in %s ===", total_plots, OUTPUT_DIR))
+message(sprintf("\n=== Done! Generated images in %s ===", OUTPUT_DIR))

--- a/team_position_breakdown.R
+++ b/team_position_breakdown.R
@@ -23,8 +23,12 @@ generate_team_position_plot <- function(
     team_name = NULL,
     top_n = 5,
     include_dh = TRUE,
-    log_scale = FALSE,  # Use pseudo-log scale for y-axis (helps see RPs vs Ruth)
-    show_postseason = FALSE  # Show vertical lines for postseason achievements
+    log_scale = FALSE,
+    show_postseason = FALSE,
+    variable_width = FALSE,
+    pos_year_stats = NULL,
+    show_awards = FALSE,
+    award_data = NULL
 ) {
   
   # Get team name if not provided
@@ -149,76 +153,18 @@ generate_team_position_plot <- function(
     left_join(best_ghosts, by = c("position", "year_ID", "player_ID")) %>%
     mutate(is_best_ghost = replace_na(is_best_ghost, FALSE))
   
-  # Order positions logically - only include positions that have data
+  # Order positions — filter first, set factor AFTER z-score join
   position_order <- c("C", "1B", "2B", "SS", "3B", "OF", "DH", "SP", "RP")
   positions_with_data <- intersect(position_order, unique(team_cum$position))
   team_cum <- team_cum %>%
-    filter(position %in% positions_with_data) %>%
-    mutate(position = factor(position, levels = positions_with_data))
+    filter(position %in% positions_with_data)
   
-  # Get team color and secondary color for "best ghost" (runner-up) players
   team_color <- primary_colors[[team_code]]
   if (is.null(team_color)) team_color <- "#333333"
   ghost_highlight_color <- secondary_colors[[team_code]]
   if (is.null(ghost_highlight_color)) ghost_highlight_color <- "#C4CED4"
   
-  # Get postseason achievements if requested
-  # Map our franchise codes to Lahman team codes (reverse mapping)
-  lahman_codes_map <- list(
-    "NYY" = c("NYA"),
-    "LAD" = c("LAN", "BRO"),
-    "SFG" = c("SFN", "NYG"),
-    "ATL" = c("ATL", "MLN", "BSN"),
-    "BAL" = c("BAL", "SLA", "MLA"),
-    "MIN" = c("MIN", "WS1", "WS2"),
-    "OAK" = c("OAK", "PHA", "KCA"),
-    "TEX" = c("TEX", "WS2"),
-    "MIL" = c("MIL", "SEA"),
-    "WSN" = c("WAS", "MON"),
-    "CHC" = c("CHN"),
-    "CIN" = c("CIN"),
-    "STL" = c("SLN"),
-    "PIT" = c("PIT"),
-    "PHI" = c("PHI"),
-    "BOS" = c("BOS"),
-    "CLE" = c("CLE"),
-    "DET" = c("DET"),
-    "CHW" = c("CHA"),
-    "SEA" = c("SEA"),
-    "TBR" = c("TBA"),
-    "TOR" = c("TOR"),
-    "HOU" = c("HOU"),
-    "LAA" = c("ANA", "CAL", "LAA"),
-    "KCR" = c("KCA"),
-    "ARI" = c("ARI"),
-    "COL" = c("COL"),
-    "SDP" = c("SDN"),
-    "MIA" = c("FLO", "MIA")
-  )
-  lahman_codes <- lahman_codes_map[[team_code]]
-  if (is.null(lahman_codes)) lahman_codes <- team_code
-  
-  postseason_data <- NULL
-  if (show_postseason) {
-    postseason_data <- Lahman::SeriesPost %>%
-      filter(teamIDwinner %in% lahman_codes) %>%
-      mutate(achievement = case_when(
-        round == "WS" ~ "World Series",
-        round %in% c("CS", "ALCS", "NLCS") ~ "Pennant/LCS",
-        grepl("DS|DIV", round) ~ "Division Series",
-        grepl("WC", round) ~ "Wild Card",
-        TRUE ~ "Pennant/LCS"  # Historical pennants
-      )) %>%
-      distinct(yearID, achievement) %>%
-      # Keep only highest achievement per year
-      mutate(achievement = factor(achievement, 
-        levels = c("World Series", "Pennant/LCS", "Division Series", "Wild Card"))) %>%
-      group_by(yearID) %>%
-      slice_min(achievement, n = 1) %>%
-      ungroup()
-  }
-  
-  # Create player category for legend
+  # Player category
   team_cum <- team_cum %>%
     mutate(player_category = case_when(
       is_top ~ "Top 5 (Team WAR)",
@@ -226,136 +172,201 @@ generate_team_position_plot <- function(
       TRUE ~ "Other Players"
     ))
   
+  # --- Z-score width for top players ---
+  top_segments <- NULL
+  if (variable_width && !is.null(pos_year_stats)) {
+    team_cum <- team_cum %>%
+      left_join(pos_year_stats, by = c("position", "year_ID")) %>%
+      mutate(
+        war_zscore = (WAR - mean_WAR) / sd_WAR,
+        war_zscore_clamped = pmin(pmax(war_zscore, 0), 4)
+      )
+    
+    top_segments <- team_cum %>%
+      filter(is_top) %>%
+      group_by(stint_id) %>%
+      arrange(year_ID) %>%
+      mutate(
+        next_year = lead(year_ID),
+        next_cumWAR = lead(cumWAR),
+        width_z = lead(war_zscore_clamped)
+      ) %>%
+      filter(!is.na(next_year), !is.na(width_z)) %>%
+      ungroup() %>%
+      mutate(position = factor(position, levels = positions_with_data))
+  }
+  
+  # Set position factor levels AFTER z-score join
+  team_cum <- team_cum %>%
+    mutate(position = factor(position, levels = positions_with_data))
+  
+  # --- Award markers ---
+  award_markers <- NULL
+  if (show_awards && !is.null(award_data)) {
+    award_markers <- team_cum %>%
+      filter(is_top) %>%
+      inner_join(award_data, by = c("player_ID" = "playerID", "year_ID" = "yearID"),
+                 relationship = "many-to-many") %>%
+      filter(award %in% c("MVP", "CYA", "AS")) %>%
+      mutate(
+        award = factor(award, levels = c("MVP", "CYA", "AS")),
+        position = factor(position, levels = positions_with_data)
+      )
+  }
+  
+  # --- Postseason data (using shared helper) ---
+  postseason_data <- NULL
+  if (show_postseason) {
+    postseason_data <- get_postseason_data(team_code)
+  }
+  
   # Create the plot
   p <- ggplot(team_cum, aes(x = year_ID, y = cumWAR)) +
-    # Ghost lines for ALL players (group by stint to break at gaps)
     geom_line(
       data = filter(team_cum, player_category == "Other Players"),
       aes(group = stint_id),
-      color = "gray60",
-      linewidth = 0.4,
-      alpha = 0.6
+      color = "gray75", linewidth = 0.3, alpha = 0.5
     )
   
-  # Add postseason vertical lines if requested
+  # Postseason vertical lines
   if (show_postseason && !is.null(postseason_data) && nrow(postseason_data) > 0) {
     p <- p + geom_vline(
       data = postseason_data,
       aes(xintercept = yearID, linetype = achievement),
-      alpha = 0.4,
-      linewidth = 0.5
+      alpha = 0.35, linewidth = 0.4
     ) +
-    scale_linetype_manual(
-      name = "Postseason",
-      values = c(
-        "World Series" = "solid",
-        "Pennant/LCS" = "dashed",
-        "Division Series" = "dotted",
-        "Wild Card" = "dotdash"
-      )
+    scale_linetype_manual(name = "Postseason",
+      values = c("World Series" = "solid", "Pennant/LCS" = "dashed",
+                 "Division Series" = "dotted", "Wild Card" = "dotdash"))
+  }
+  
+  # Best ghost lines
+  p <- p + geom_line(
+    data = filter(team_cum, player_category == "Best in Gap Years (2+ yr)"),
+    aes(group = stint_id, color = player_category),
+    linewidth = 0.7, show.legend = TRUE
+  )
+  
+  # Top players: z-score segments or constant lines
+  if (!is.null(top_segments) && nrow(top_segments) > 0) {
+    p <- p + geom_segment(
+      data = top_segments,
+      aes(x = year_ID, xend = next_year, y = cumWAR, yend = next_cumWAR,
+          linewidth = width_z, color = player_category),
+      lineend = "round", linejoin = "round", show.legend = TRUE
+    ) +
+    scale_linewidth_continuous(
+      name = "Positional Dominance (σ above mean)",
+      range = c(0.3, 5),
+      breaks = c(0, 1, 2, 3, 4),
+      labels = c("Avg", "+1σ", "+2σ", "+3σ", "+4σ")
+    )
+  } else {
+    p <- p + geom_line(
+      data = filter(team_cum, player_category == "Top 5 (Team WAR)"),
+      aes(group = stint_id, color = player_category),
+      linewidth = 1.2, show.legend = TRUE
     )
   }
   
+  # Award markers
+  if (!is.null(award_markers) && nrow(award_markers) > 0) {
+    p <- p + geom_point(
+      data = award_markers,
+      aes(shape = award, size = award, fill = award),
+      color = "black", stroke = 0.5
+    ) +
+    scale_shape_manual(name = "Awards",
+      values = c("MVP" = 23, "CYA" = 24, "AS" = 21)) +
+    scale_size_manual(name = "Awards",
+      values = c("MVP" = 4, "CYA" = 4, "AS" = 1.5)) +
+    scale_fill_manual(name = "Awards",
+      values = c("MVP" = "gold", "CYA" = "gold", "AS" = "gray80"))
+  }
+  
+  # Color scale + labels
   p <- p +
-    # Best ghost lines (years with no top player)
-    geom_line(
-      data = filter(team_cum, player_category == "Best in Gap Years (2+ yr)"),
-      aes(group = stint_id, color = player_category),
-      linewidth = 0.8,
-      show.legend = TRUE
-    ) +
-    # Highlighted lines for top players
-    geom_line(
-      data = filter(team_cum, player_category == "Top 5 (Team WAR)"),
-      aes(group = stint_id, color = player_category),
-      linewidth = 1.2,
-      show.legend = TRUE
-    ) +
-    # Color scale for legend
-    scale_color_manual(
-      name = NULL,
-      values = c(
-        "Top 5 (Team WAR)" = team_color,
-        "Best in Gap Years (2+ yr)" = ghost_highlight_color
-      ),
+    scale_color_manual(name = NULL,
+      values = c("Top 5 (Team WAR)" = team_color,
+                 "Best in Gap Years (2+ yr)" = ghost_highlight_color),
       guide = guide_legend(override.aes = list(linewidth = 2))
     ) +
-    # Labels for top players (only stints with 2+ years)
     geom_label_repel(
       data = team_cum %>%
         filter(is_top) %>%
         group_by(position, player_ID, stint_id) %>%
-        filter(n() >= 2) %>%  # Only label stints with 2+ years
+        filter(n() >= 2) %>%
         filter(year_ID == max(year_ID)) %>%
         ungroup(),
       aes(label = name_common),
       color = team_color,
-      size = 2.5,
-      fill = alpha("white", 0.9),
-      label.size = 0,
-      segment.size = 0.3,
-      segment.alpha = 0.5,
-      max.overlaps = 10,
-      nudge_y = 2,
-      box.padding = 0.2
+      size = 2.5, fill = alpha("white", 0.9), label.size = 0,
+      segment.size = 0.3, segment.alpha = 0.5,
+      max.overlaps = 10, nudge_y = 2, box.padding = 0.2
     ) +
-    # Labels for best ghosts (only if 2+ years as best ghost, per stint)
     geom_label_repel(
       data = team_cum %>%
         filter(is_best_ghost) %>%
         group_by(position, player_ID, stint_id) %>%
-        filter(n() >= 2) %>%  # Only label if 2+ years as best ghost in this stint
+        filter(n() >= 2) %>%
         filter(year_ID == max(year_ID)) %>%
         ungroup(),
       aes(label = name_common),
       color = ghost_highlight_color,
-      size = 2,
-      fill = alpha("white", 0.85),
-      label.size = 0,
-      segment.size = 0.2,
-      segment.alpha = 0.4,
-      max.overlaps = 5,
-      nudge_y = -1,
-      box.padding = 0.15
+      size = 2, fill = alpha("white", 0.85), label.size = 0,
+      segment.size = 0.2, segment.alpha = 0.4,
+      max.overlaps = 5, nudge_y = -1, box.padding = 0.15
     ) +
-    # Facet by position - one row per position, same y-axis, x-axis on all
     ggh4x::facet_wrap2(~ position, ncol = 1, axes = "x") +
-    # Axis settings - dynamic breaks based on team start year
     coord_cartesian(xlim = c(start_year, 2026)) +
     scale_x_continuous(
-      breaks = seq(ceiling(start_year / 10) * 10, 2020, 10)  # Start at first decade
+      breaks = seq(ceiling(start_year / 10) * 10, 2020, 10)
     )
   
-  # Conditional y-scale: log or linear
   if (log_scale) {
     p <- p + scale_y_continuous(
-      trans = "pseudo_log",  # Handles 0 and negative values
+      trans = "pseudo_log",
       breaks = c(0, 5, 10, 20, 50, 100, 150)
     )
   }
   
+  # Build subtitle
+  subtitle_parts <- paste0("Top ", top_n, " players per position highlighted")
+  if (!is.null(top_segments) && nrow(top_segments) > 0) {
+    subtitle_parts <- paste0(subtitle_parts, " | Line width = positional dominance (σ)")
+  }
+  
   p <- p +
-    # Theme - light grid for ghost line contrast
     theme_minimal() +
     theme(
       legend.position = "top",
       legend.justification = "left",
-      legend.margin = margin(0, 0, 10, 0),
-      panel.spacing = unit(1, "lines"),
+      legend.box = "horizontal",
+      legend.box.just = "left",
+      legend.margin = margin(0, 0, 5, 0),
+      legend.spacing.x = unit(0.8, "cm"),
+      panel.spacing = unit(0.8, "lines"),
       strip.text = element_text(face = "bold", size = 11),
       axis.text = element_text(size = 8),
-      panel.grid.major = element_line(color = "gray90", linewidth = 0.3),
+      panel.grid.major = element_line(color = "gray92", linewidth = 0.3),
       panel.grid.minor = element_blank(),
       panel.background = element_rect(fill = "white", color = NA),
       plot.title = element_text(size = 16, face = "bold"),
       plot.subtitle = element_text(size = 11, color = "#666")
     ) +
+    guides(
+      color = guide_legend(order = 1),
+      linetype = guide_legend(order = 2),
+      shape = guide_legend(order = 3),
+      size = guide_legend(order = 3),
+      fill = guide_legend(order = 3),
+      linewidth = guide_legend(order = 4)
+    ) +
     labs(
       title = paste0(team_name, " — Cumulative WAR by Position"),
-      subtitle = paste0("Top ", top_n, " players per position highlighted (", start_year, "-Present)"),
-      x = "Year",
-      y = "Cumulative WAR",
-      caption = "Source: Baseball Reference | Gray lines show all other players"
+      subtitle = paste0(subtitle_parts, " (", start_year, "-Present)"),
+      x = "Year", y = "Cumulative WAR",
+      caption = "Source: Baseball Reference + Lahman"
     )
   
   # Attach position count for dynamic sizing


### PR DESCRIPTION
## Summary

Adds dense visualization features to both the 30-team grid explorer and per-team position breakdown charts:

### New features
- **Z-score line width**: Line thickness encodes positional dominance (σ above league mean for that position/year). Decouples from slope — a 5-WAR catcher season shows thicker than 5-WAR OF because it's more unusual.
- **Award markers**: MVP (gold diamond), Cy Young (gold triangle), All-Star (gray dot) from Lahman database
- **Postseason overlays**: World Series, LCS, DS, Wild Card vertical line markers

### Shared infrastructure (`franchise_war_functions.R`)
- `compute_position_year_stats()` — league-wide position×year z-score stats
- `load_award_data()` — MVP, CYA, All-Star from Lahman
- `get_postseason_data()` — shared postseason helper with LAHMAN_CODES mapping
- `save_overlay_png()` — transparent PNG overlay generation

### Batch scripts
- `generate_all_plots.R`: Now generates constant + z-score bases, award + postseason overlays per position×era
- `generate_team_breakdowns.R`: 2 scales × 2 widths bases + overlays per team

### Architecture
Overlay PNGs are pixel-aligned transparent images that stack via CSS `position: absolute` in the HTML viewers. This enables instant browser-side toggling without reloading full images.

Follow-up PRs:
- PR #2: Run batch generation (~504 PNGs)
- PR #3: HTML viewers with toggle UI + landing page