### PR TITLE
feat: landing page, team breakdown viewer, overlay toggles

### DIFF
--- a/docs/landing.html
+++ b/docs/landing.html
@@ -116,28 +116,39 @@
     <div class="section">
       <h2>What Is This?</h2>
       <p>
-        I had the idea for this project in 2019 while playing around with FanGraph's [Cumulative WAR by Age](https://www.fangraphs.com/leaders/war-graphs?players=4772&wg=2) charts. I was comparing charts for good Mariners at different positions across the team's history, and thought that being able to graph them "in time" would be an interesting storytelling visualization. There's no particular <i>analytical</i> value to these, but you can see the peaks and troughs in a franchise's history, and there are occasional surprises, and interesting players I'd never heard of, that I learned about while playing around with these.
-
-        I got partway into the project in 2020 before being derailed by life, as well as my own lack of R skills. Luckily Copilot is good at R, and I finished my intial vision in a couple weekends of work in 2026.
-    
+        I had the idea for this project in 2019 while playing around with FanGraph's
+        <a href="https://www.fangraphs.com/leaders/war-graphs?players=4772&wg=2">Cumulative WAR by Age</a>
+        charts. I was comparing charts for good Mariners at different positions across the team's
+        history, and thought that being able to graph them "in time" would be an interesting
+        storytelling visualization. There's no particular <em>analytical</em> value to these, but you
+        can see the peaks and troughs in a franchise's history, and there are occasional surprises,
+        and interesting players I'd never heard of, that I learned about while playing around with these.
+      </p>
+      <p>
+        I got partway into the project in 2020 before being derailed by life, as well as my own lack
+        of R skills. Luckily Copilot is good at R, and I finished my initial vision in a couple
+        weekends of work in 2026.
       </p>
     </div>
 
     <div class="section">
       <h2>Reading the Charts</h2>
-                 <p>
-                   These visualizations chart <strong>cumulative WAR (Wins Above Replacement)</strong> over time
+      <p>
+        These visualizations chart <strong>cumulative WAR (Wins Above Replacement)</strong> over time
         for the top players at each MLB franchise. Each line traces a player's career value as it
         accumulates season by season — steeper lines mean peak performance years, flat sections mean
         missed time or league-average play. The higher a line ends, the more total value that player
-        delivered to that franchise. Of course this necessarily de-emphasizes the contributions of players who moved between teams frequently, or perhaps had one or two standout seasons. That is by design.
-                      </p>
+        delivered to that franchise. Of course this necessarily de-emphasizes the contributions of
+        players who moved between teams frequently, or perhaps had one or two standout seasons.
+        That is by design.
+      </p>
       <p>
         <strong>Z-Score Line Width:</strong> When enabled, line thickness encodes how exceptional a
         player's WAR was <em>relative to their position and era</em>. Specifically, the width
         represents the number of standard deviations above the league mean WAR for that
         position-year combination. Thicker lines = more dominant seasons compared to peers at the
-        same position. Of course this correlates strongly with slope, but truly exceptional seasons like Cal Raleigh's 2025 really pop.
+        same position. Of course this correlates strongly with slope, but truly exceptional seasons
+        like Cal Raleigh's 2025 really pop.
       </p>
       <p>
         <strong>Overlay Markers:</strong> Award markers can be toggled on top of the WAR lines.
@@ -164,7 +175,8 @@
         <p>
           Dive into a single franchise with a 9-facet view — one panel per position.
           Compare how a team has built value at each position over its history, with
-          linear or log scale options for the Y axis. The log scale compresses peaks, but makes the low-WAR positions like relief pitcher easier to read and compare.
+          linear or log scale options for the Y axis. The log scale compresses peaks,
+          but makes the low-WAR positions like relief pitcher easier to read and compare.
         </p>
         <span class="arrow">Open Breakdown →</span>
       </a>
@@ -182,6 +194,8 @@
 
     <footer>
       <a href="https://github.com/keownb/R-Baseball-Experiments" target="_blank">View Source on GitHub</a>
+      &nbsp;|&nbsp;
+      <a href="mailto:keownb+baseball@gmail.com">Send Feedback</a>
     </footer>
   </div>
 </body>

--- a/docs/landing.html
+++ b/docs/landing.html
@@ -116,22 +116,28 @@
     <div class="section">
       <h2>What Is This?</h2>
       <p>
-        These visualizations chart <strong>cumulative WAR (Wins Above Replacement)</strong> over time
-        for the top players at each MLB franchise. Each line traces a player's career value as it
-        accumulates season by season — steeper lines mean peak performance years, flat sections mean
-        missed time or league-average play. The higher a line ends, the more total value that player
-        delivered to that franchise.
+        I had the idea for this project in 2019 while playing around with FanGraph's [Cumulative WAR by Age](https://www.fangraphs.com/leaders/war-graphs?players=4772&wg=2) charts. I was comparing charts for good Mariners at different positions across the team's history, and thought that being able to graph them "in time" would be an interesting storytelling visualization. There's no particular <i>analytical</i> value to these, but you can see the peaks and troughs in a franchise's history, and there are occasional surprises, and interesting players I'd never heard of, that I learned about while playing around with these.
+
+        I got partway into the project in 2020 before being derailed by life, as well as my own lack of R skills. Luckily Copilot is good at R, and I finished my intial vision in a couple weekends of work in 2026.
+    
       </p>
     </div>
 
     <div class="section">
       <h2>Reading the Charts</h2>
+                 <p>
+                   These visualizations chart <strong>cumulative WAR (Wins Above Replacement)</strong> over time
+        for the top players at each MLB franchise. Each line traces a player's career value as it
+        accumulates season by season — steeper lines mean peak performance years, flat sections mean
+        missed time or league-average play. The higher a line ends, the more total value that player
+        delivered to that franchise. Of course this necessarily de-emphasizes the contributions of players who moved between teams frequently, or perhaps had one or two standout seasons. That is by design.
+                      </p>
       <p>
         <strong>Z-Score Line Width:</strong> When enabled, line thickness encodes how exceptional a
         player's WAR was <em>relative to their position and era</em>. Specifically, the width
         represents the number of standard deviations above the league mean WAR for that
         position-year combination. Thicker lines = more dominant seasons compared to peers at the
-        same position.
+        same position. Of course this correlates strongly with slope, but truly exceptional seasons like Cal Raleigh's 2025 really pop.
       </p>
       <p>
         <strong>Overlay Markers:</strong> Award markers can be toggled on top of the WAR lines.
@@ -158,7 +164,7 @@
         <p>
           Dive into a single franchise with a 9-facet view — one panel per position.
           Compare how a team has built value at each position over its history, with
-          linear or log scale options.
+          linear or log scale options for the Y axis. The log scale compresses peaks, but makes the low-WAR positions like relief pitcher easier to read and compare.
         </p>
         <span class="arrow">Open Breakdown →</span>
       </a>

--- a/docs/landing.html
+++ b/docs/landing.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MLB Franchise WAR Visualizations</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+    .display-warning {
+      background: #f5c518;
+      color: #1a1a2e;
+      text-align: center;
+      padding: 10px 20px;
+      font-weight: 700;
+      font-size: 14px;
+    }
+    .container {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 2.2rem;
+      color: #fff;
+      margin-bottom: 8px;
+    }
+    .subtitle {
+      text-align: center;
+      color: #8888aa;
+      font-size: 1rem;
+      margin-bottom: 40px;
+    }
+    .section {
+      background: #16213e;
+      border-radius: 10px;
+      padding: 28px 32px;
+      margin-bottom: 24px;
+      border: 1px solid #1f3460;
+    }
+    .section h2 {
+      color: #7ec8e3;
+      font-size: 1.2rem;
+      margin-bottom: 12px;
+    }
+    .section p {
+      line-height: 1.7;
+      color: #c0c0d0;
+      margin-bottom: 12px;
+    }
+    .section p:last-child { margin-bottom: 0; }
+    .cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      margin-bottom: 24px;
+    }
+    .card {
+      background: #16213e;
+      border: 1px solid #1f3460;
+      border-radius: 10px;
+      padding: 32px;
+      text-decoration: none;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .card:hover {
+      border-color: #7ec8e3;
+      transform: translateY(-3px);
+    }
+    .card h3 {
+      color: #7ec8e3;
+      font-size: 1.3rem;
+      margin-bottom: 10px;
+    }
+    .card p {
+      color: #a0a0b8;
+      line-height: 1.6;
+      font-size: 0.95rem;
+    }
+    .card .arrow {
+      display: inline-block;
+      margin-top: 16px;
+      color: #7ec8e3;
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    footer {
+      text-align: center;
+      margin-top: 40px;
+      padding: 20px;
+      color: #666;
+      font-size: 13px;
+      border-top: 1px solid #1f3460;
+    }
+    footer a {
+      color: #7ec8e3;
+      text-decoration: none;
+    }
+    footer a:hover { text-decoration: underline; }
+    a { color: #7ec8e3; }
+  </style>
+</head>
+<body>
+  <div class="display-warning">⚠️ Built for 27″+ displays. Not optimized for mobile.</div>
+
+  <div class="container">
+    <h1>⚾ MLB Franchise WAR Visualizations</h1>
+    <p class="subtitle">Cumulative career WAR trajectories for every MLB franchise</p>
+
+    <div class="section">
+      <h2>What Is This?</h2>
+      <p>
+        These visualizations chart <strong>cumulative WAR (Wins Above Replacement)</strong> over time
+        for the top players at each MLB franchise. Each line traces a player's career value as it
+        accumulates season by season — steeper lines mean peak performance years, flat sections mean
+        missed time or league-average play. The higher a line ends, the more total value that player
+        delivered to that franchise.
+      </p>
+    </div>
+
+    <div class="section">
+      <h2>Reading the Charts</h2>
+      <p>
+        <strong>Z-Score Line Width:</strong> When enabled, line thickness encodes how exceptional a
+        player's WAR was <em>relative to their position and era</em>. Specifically, the width
+        represents the number of standard deviations above the league mean WAR for that
+        position-year combination. Thicker lines = more dominant seasons compared to peers at the
+        same position.
+      </p>
+      <p>
+        <strong>Overlay Markers:</strong> Award markers can be toggled on top of the WAR lines.
+        <strong>♦ Diamonds</strong> mark MVP awards, <strong>▲ triangles</strong> mark Cy Young
+        Awards, and <strong>● dots</strong> mark All-Star selections. Postseason overlays add
+        vertical lines at each year the franchise appeared in the playoffs, providing context for
+        when teams were contending.
+      </p>
+    </div>
+
+    <div class="cards">
+      <a href="war_explorer.html" class="card">
+        <h3>Franchise WAR Grid Explorer</h3>
+        <p>
+          The 30-team grid view. See all franchises side by side, filter by position
+          (C, 1B, 2B, SS, 3B, OF, SP, RP) and era (1901–present). Toggle z-score
+          line widths, award markers, and postseason indicators.
+        </p>
+        <span class="arrow">Open Explorer →</span>
+      </a>
+
+      <a href="team_breakdown.html" class="card">
+        <h3>Team Position Breakdown</h3>
+        <p>
+          Dive into a single franchise with a 9-facet view — one panel per position.
+          Compare how a team has built value at each position over its history, with
+          linear or log scale options.
+        </p>
+        <span class="arrow">Open Breakdown →</span>
+      </a>
+    </div>
+
+    <div class="section">
+      <h2>Data Sources</h2>
+      <p>
+        WAR data from
+        <a href="https://www.baseball-reference.com/data/" target="_blank">Baseball Reference</a>.
+        Position classification from the
+        <a href="https://github.com/chadwickbureau/baseballdatabank" target="_blank">Lahman Database</a>.
+      </p>
+    </div>
+
+    <footer>
+      <a href="https://github.com/keownb/R-Baseball-Experiments" target="_blank">View Source on GitHub</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/docs/landing.html
+++ b/docs/landing.html
@@ -121,8 +121,8 @@
         charts. I was comparing charts for good Mariners at different positions across the team's
         history, and thought that being able to graph them "in time" would be an interesting
         storytelling visualization. There's no particular <em>analytical</em> value to these, but you
-        can see the peaks and troughs in a franchise's history, and there are occasional surprises,
-        and interesting players I'd never heard of, that I learned about while playing around with these.
+        can see the peaks and troughs in a franchise's history, and there are occasional surprises
+        and interesting players that you'll find looking through the graphs.
       </p>
       <p>
         I got partway into the project in 2020 before being derailed by life, as well as my own lack

--- a/docs/team_breakdown.html
+++ b/docs/team_breakdown.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MLB Franchise WAR Explorer</title>
+  <title>Team Position Breakdown — MLB WAR</title>
   <script src="https://unpkg.com/@panzoom/panzoom@4.5.1/dist/panzoom.min.js"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -31,9 +31,6 @@
       color: #fff;
       margin-bottom: 10px;
       font-size: 1.6rem;
-      max-width: 1600px;
-      margin-left: auto;
-      margin-right: auto;
     }
     .intro {
       background: #16213e;
@@ -44,14 +41,10 @@
       max-width: 1600px;
     }
     .intro p {
-      margin: 0 0 12px 0;
       line-height: 1.6;
       color: #b0b0c8;
       font-size: 0.92rem;
     }
-    .intro p:last-child { margin-bottom: 0; }
-    .intro strong { color: #e0e0e0; }
-    .intro a { color: #7ec8e3; }
     .controls {
       display: flex;
       gap: 20px;
@@ -156,7 +149,7 @@
     }
     .image-wrapper {
       width: 100%;
-      height: 70vh;
+      height: 75vh;
       overflow: hidden;
       cursor: grab;
       border: 1px solid #1f3460;
@@ -178,23 +171,6 @@
       display: none;
       pointer-events: none;
     }
-    .era-info {
-      font-size: 13px;
-      color: #8888aa;
-      margin-top: 12px;
-      padding: 10px 15px;
-      background: #0f1a36;
-      border-radius: 4px;
-    }
-    .data-link {
-      margin-top: 10px;
-      font-size: 12px;
-    }
-    .data-link a {
-      color: #7ec8e3;
-      text-decoration: none;
-    }
-    .data-link a:hover { text-decoration: underline; }
     footer {
       text-align: center;
       max-width: 1600px;
@@ -214,67 +190,81 @@
 <body>
   <div class="nav" style="max-width:1600px;">
     <div><a href="landing.html">← Back to Home</a></div>
-    <div><a href="team_breakdown.html">Team Breakdown →</a></div>
+    <div><a href="war_explorer.html">← Grid Explorer</a></div>
   </div>
 
-  <h1>⚾ MLB Franchise WAR Explorer</h1>
-  
+  <h1>⚾ Team Position Breakdown</h1>
+
   <div class="intro">
     <p>
-      <strong>What is this?</strong> An interactive visualization of cumulative 
-      <a href="https://www.baseball-reference.com/about/war_explained.shtml" target="_blank">WAR (Wins Above Replacement)</a> 
-      for each of MLB's 30 franchises. Each chart shows the top 5 players by total WAR accumulated 
-      <em>with that specific franchise</em>. While this visualization has minimal pure "analytical" value, I find that it provides an interesting slice of the "story" of which teams have collected powerhouse careers, and there are some interesting tidbits in looking at the outliers.    </p>
-    <p>
-      <strong>How to read it:</strong> Steeper lines = faster WAR accumulation (peak years). 
-      Flat lines = missed time or league-average play. The higher a line ends, the more value 
-      that player provided to that franchise over their tenure. The teams you'd expect have lots of steep tall lines. Obviously the newer franchises have a certain disadvantage, so you can filter by starting year for fairer comparisons.
-    </p>
-    <p>
-      <strong>Historical mapping:</strong> All historical team names are mapped to current franchises 
-      (e.g., Montreal Expos → Washington Nationals, Brooklyn Dodgers → LA Dodgers). 
-      Filter by expansion era to compare franchises on equal footing.
+      A per-team breakdown of cumulative WAR, split into 9 facets — one for each fielding position
+      (C, 1B, 2B, SS, 3B, OF, SP, RP, DH). See how a single franchise has built value at each
+      position across its history. Toggle between linear and log scales, z-score line widths, and
+      overlay award markers or postseason indicators.
     </p>
   </div>
-  
+
   <div class="controls">
     <div class="control-group">
-      <label for="position">Position</label>
-      <select id="position">
-        <option value="all">All Players</option>
-        <option value="batters">Position Players</option>
-        <option value="pitchers">All Pitchers</option>
-        <optgroup label="Position Players">
-          <option value="c">Catcher (C)</option>
-          <option value="1b">First Base (1B)</option>
-          <option value="2b">Second Base (2B)</option>
-          <option value="ss">Shortstop (SS)</option>
-          <option value="3b">Third Base (3B)</option>
-          <option value="of">Outfield (OF)</option>
+      <label for="team">Team</label>
+      <select id="team">
+        <optgroup label="AL East">
+          <option value="BAL">Baltimore Orioles</option>
+          <option value="BOS">Boston Red Sox</option>
+          <option value="NYY">New York Yankees</option>
+          <option value="TBR">Tampa Bay Rays</option>
+          <option value="TOR">Toronto Blue Jays</option>
         </optgroup>
-        <optgroup label="Pitchers">
-          <option value="sp">Starting Pitchers (SP)</option>
-          <option value="rp">Relief Pitchers (RP)</option>
+        <optgroup label="AL Central">
+          <option value="CHW">Chicago White Sox</option>
+          <option value="CLE">Cleveland Guardians</option>
+          <option value="DET">Detroit Tigers</option>
+          <option value="KCR">Kansas City Royals</option>
+          <option value="MIN">Minnesota Twins</option>
+        </optgroup>
+        <optgroup label="AL West">
+          <option value="HOU">Houston Astros</option>
+          <option value="LAA">Los Angeles Angels</option>
+          <option value="OAK">Oakland Athletics</option>
+          <option value="SEA" selected>Seattle Mariners</option>
+          <option value="TEX">Texas Rangers</option>
+        </optgroup>
+        <optgroup label="NL East">
+          <option value="ATL">Atlanta Braves</option>
+          <option value="MIA">Miami Marlins</option>
+          <option value="NYM">New York Mets</option>
+          <option value="PHI">Philadelphia Phillies</option>
+          <option value="WSN">Washington Nationals</option>
+        </optgroup>
+        <optgroup label="NL Central">
+          <option value="CHC">Chicago Cubs</option>
+          <option value="CIN">Cincinnati Reds</option>
+          <option value="MIL">Milwaukee Brewers</option>
+          <option value="PIT">Pittsburgh Pirates</option>
+          <option value="STL">St. Louis Cardinals</option>
+        </optgroup>
+        <optgroup label="NL West">
+          <option value="ARI">Arizona Diamondbacks</option>
+          <option value="COL">Colorado Rockies</option>
+          <option value="LAD">Los Angeles Dodgers</option>
+          <option value="SDP">San Diego Padres</option>
+          <option value="SFG">San Francisco Giants</option>
         </optgroup>
       </select>
     </div>
-    
+
     <div class="control-group">
-      <label for="era">Era</label>
-      <select id="era">
-        <option value="1901">1901 — Full History</option>
-        <option value="1961">1961 — First Expansion</option>
-        <option value="1969">1969 — Divisional Era</option>
-        <option value="1977">1977 — SEA/TOR Join</option>
-        <option value="1993">1993 — COL/MIA Join</option>
-        <option value="1998">1998 — ARI/TBR (30 Teams)</option>
+      <label for="scale">Scale</label>
+      <select id="scale">
+        <option value="linear">Linear</option>
+        <option value="log">Log</option>
       </select>
     </div>
 
     <div class="control-group">
       <label for="line-width">Line Width</label>
       <select id="line-width">
-        <option value="constant">Constant</option>
+        <option value="const">Constant</option>
         <option value="zscore">Z-Score</option>
       </select>
     </div>
@@ -294,25 +284,21 @@
         <label for="postseason">Postseason</label>
       </div>
     </div>
-    
+
     <button class="reset-btn" id="reset-zoom">Reset Zoom</button>
   </div>
-  
+
   <div class="plot-container">
     <div class="plot-header">
-      <div class="plot-title" id="plot-title">Cumulative WAR by Franchise — All Players (1901-Present)</div>
+      <div class="plot-title" id="plot-title">Seattle Mariners — Position Breakdown (Linear, Constant Width)</div>
       <div class="zoom-hint">🔍 Scroll to zoom · Drag to pan</div>
     </div>
     <div class="image-wrapper" id="image-wrapper">
       <div class="panzoom-container" id="panzoom-container" style="position: relative;">
-        <img id="plot-image" src="plots/all_1901.png" alt="WAR Plot" style="width:100%; display:block;">
+        <img id="plot-image" src="team_breakdowns/SEA_linear_const.png" alt="Team Breakdown Plot" style="width:100%; display:block;">
         <img id="awards-overlay" class="overlay" src="" alt="">
         <img id="postseason-overlay" class="overlay" src="" alt="">
       </div>
-    </div>
-    <div class="era-info" id="era-info"></div>
-    <div class="data-link">
-      📊 <a href="#" id="csv-link" target="_blank">Download data (CSV)</a>
     </div>
   </div>
 
@@ -323,34 +309,21 @@
   </footer>
 
   <script>
-    const eraInfo = {
-      '1901': 'Modern era begins (1901). Includes all historical franchises mapped to their current names.',
-      '1961': 'First expansion (1961): Angels and new Senators (→ Rangers) join. Astros & Mets follow in 1962.',
-      '1969': 'Divisional play begins (1969): Padres, Expos (→ Nationals), Pilots (→ Brewers), Royals join.',
-      '1977': 'AL expansion (1977): Mariners and Blue Jays join, completing the 14-team AL.',
-      '1993': 'NL expansion (1993): Rockies and Marlins join, bringing MLB to 28 teams.',
-      '1998': 'Final expansion (1998): Diamondbacks and Devil Rays complete the current 30-team format.'
+    const teamNames = {
+      BAL: 'Baltimore Orioles', BOS: 'Boston Red Sox', NYY: 'New York Yankees',
+      TBR: 'Tampa Bay Rays', TOR: 'Toronto Blue Jays', CHW: 'Chicago White Sox',
+      CLE: 'Cleveland Guardians', DET: 'Detroit Tigers', KCR: 'Kansas City Royals',
+      MIN: 'Minnesota Twins', HOU: 'Houston Astros', LAA: 'Los Angeles Angels',
+      OAK: 'Oakland Athletics', SEA: 'Seattle Mariners', TEX: 'Texas Rangers',
+      ATL: 'Atlanta Braves', MIA: 'Miami Marlins', NYM: 'New York Mets',
+      PHI: 'Philadelphia Phillies', WSN: 'Washington Nationals', CHC: 'Chicago Cubs',
+      CIN: 'Cincinnati Reds', MIL: 'Milwaukee Brewers', PIT: 'Pittsburgh Pirates',
+      STL: 'St. Louis Cardinals', ARI: 'Arizona Diamondbacks', COL: 'Colorado Rockies',
+      LAD: 'Los Angeles Dodgers', SDP: 'San Diego Padres', SFG: 'San Francisco Giants'
     };
 
-    const positionLabels = {
-      'all': 'All Players',
-      'batters': 'Position Players',
-      'pitchers': 'All Pitchers',
-      'c': 'Catchers (C)',
-      '1b': 'First Basemen (1B)',
-      '2b': 'Second Basemen (2B)',
-      'ss': 'Shortstops (SS)',
-      '3b': 'Third Basemen (3B)',
-      'of': 'Outfielders (OF)',
-      'sp': 'Starting Pitchers (SP)',
-      'rp': 'Relief Pitchers (RP)'
-    };
-
-    // Positions that support z-score width
-    const singlePositions = new Set(['c', '1b', '2b', 'ss', '3b', 'of', 'sp', 'rp']);
-
-    const positionSelect = document.getElementById('position');
-    const eraSelect = document.getElementById('era');
+    const teamSelect = document.getElementById('team');
+    const scaleSelect = document.getElementById('scale');
     const widthSelect = document.getElementById('line-width');
     const awardsCheck = document.getElementById('awards');
     const postseasonCheck = document.getElementById('postseason');
@@ -358,13 +331,10 @@
     const awardsOverlay = document.getElementById('awards-overlay');
     const postseasonOverlay = document.getElementById('postseason-overlay');
     const plotTitle = document.getElementById('plot-title');
-    const eraInfoDiv = document.getElementById('era-info');
-    const csvLink = document.getElementById('csv-link');
-    const imageWrapper = document.getElementById('image-wrapper');
-    const panzoomContainer = document.getElementById('panzoom-container');
     const resetBtn = document.getElementById('reset-zoom');
+    const panzoomContainer = document.getElementById('panzoom-container');
+    const imageWrapper = document.getElementById('image-wrapper');
 
-    // Initialize Panzoom on the container so all layers zoom/pan together
     const panzoom = Panzoom(panzoomContainer, {
       maxScale: 5,
       minScale: 0.5,
@@ -377,40 +347,20 @@
       panzoom.reset({ animate: false });
     }
 
-    // Enforce z-score availability based on position selection
-    function updateWidthAvailability() {
-      const pos = positionSelect.value;
-      if (!singlePositions.has(pos)) {
-        widthSelect.value = 'constant';
-        widthSelect.disabled = true;
-      } else {
-        widthSelect.disabled = false;
-      }
-    }
-
     function updatePlot() {
-      const position = positionSelect.value;
-      const era = eraSelect.value;
+      const team = teamSelect.value;
+      const scale = scaleSelect.value;
       const width = widthSelect.value;
       const showAwards = awardsCheck.checked;
       const showPostseason = postseasonCheck.checked;
-      
-      updateWidthAvailability();
 
-      // Build base filename
-      const baseName = `${position}_${era}`;
-      const effectiveWidth = widthSelect.value; // re-read after availability update
-
-      // Base image: constant or z-score
-      if (effectiveWidth === 'zscore' && singlePositions.has(position)) {
-        plotImage.src = `plots/${baseName}_zscore.png`;
-      } else {
-        plotImage.src = `plots/${baseName}.png`;
-      }
+      // Base image
+      plotImage.src = `team_breakdowns/${team}_${scale}_${width}.png`;
+      plotImage.onload = resetZoom;
 
       // Awards overlay
       if (showAwards) {
-        awardsOverlay.src = `plots/${baseName}_awards.png`;
+        awardsOverlay.src = `team_breakdowns/${team}_${scale}_awards.png`;
         awardsOverlay.style.display = 'block';
       } else {
         awardsOverlay.style.display = 'none';
@@ -419,39 +369,30 @@
 
       // Postseason overlay
       if (showPostseason) {
-        postseasonOverlay.src = `plots/${baseName}_postseason.png`;
+        postseasonOverlay.src = `team_breakdowns/${team}_${scale}_postseason.png`;
         postseasonOverlay.style.display = 'block';
       } else {
         postseasonOverlay.style.display = 'none';
         postseasonOverlay.src = '';
       }
 
-      // CSV link
-      csvLink.href = `data/${baseName}.csv`;
-      
-      // Reset zoom on new image
-      plotImage.onload = resetZoom;
-      
-      // Update title
-      const typeLabel = positionLabels[position] || position.toUpperCase();
-      plotTitle.textContent = `Cumulative WAR by Franchise — ${typeLabel} (${era}-Present)`;
-      
-      // Update era info
-      eraInfoDiv.textContent = eraInfo[era];
+      // Title
+      const name = teamNames[team] || team;
+      const scaleLabel = scale === 'linear' ? 'Linear' : 'Log';
+      const widthLabel = width === 'const' ? 'Constant Width' : 'Z-Score Width';
+      plotTitle.textContent = `${name} — Position Breakdown (${scaleLabel}, ${widthLabel})`;
     }
 
-    positionSelect.addEventListener('change', updatePlot);
-    eraSelect.addEventListener('change', updatePlot);
+    teamSelect.addEventListener('change', updatePlot);
+    scaleSelect.addEventListener('change', updatePlot);
     widthSelect.addEventListener('change', updatePlot);
     awardsCheck.addEventListener('change', updatePlot);
     postseasonCheck.addEventListener('change', updatePlot);
-    
-    // Handle image load errors
+
     plotImage.addEventListener('error', function() {
-      this.alt = 'Plot not yet generated. Run generate_all_plots.R first.';
+      this.alt = 'Plot not yet generated. Run the R scripts first.';
     });
 
-    // Initialize
     updatePlot();
   </script>
 </body>


### PR DESCRIPTION
## Summary

Landing page and updated HTML viewers with overlay toggle support. Depends on PR #9.

### New: `docs/landing.html`
- Project introduction with ⚠️ **27"+ display notice** prominently at top
- Explains cumulative WAR, z-score width, and overlay features
- Cards linking to both explorer views
- Dark theme, data source credits

### New: `docs/team_breakdown.html`
- Per-team position breakdown viewer
- Team dropdown (30 teams organized by division, default: SEA)
- Scale toggle (Linear/Log), Line Width toggle (Constant/Z-Score)
- Awards + Postseason overlay checkboxes
- Panzoom with overlay stacking

### Updated: `docs/war_explorer.html`
- Line Width dropdown: Constant/Z-Score (auto-disables for aggregate positions)
- Awards + Postseason overlay checkboxes
- CSS overlay stacking: transparent PNGs positioned absolutely inside panzoom container
- All layers zoom/pan together
- Nav links between all three pages
- Updated to dark theme matching other pages