### PR TITLE
Pre-rendered image approach: code + HTML updates

### DIFF
--- a/docs/landing.html
+++ b/docs/landing.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MLB Franchise WAR Visualizations</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+    .display-warning {
+      background: #f5c518;
+      color: #1a1a2e;
+      text-align: center;
+      padding: 10px 20px;
+      font-weight: 700;
+      font-size: 14px;
+    }
+    .container {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 2.2rem;
+      color: #fff;
+      margin-bottom: 8px;
+    }
+    .subtitle {
+      text-align: center;
+      color: #8888aa;
+      font-size: 1rem;
+      margin-bottom: 40px;
+    }
+    .section {
+      background: #16213e;
+      border-radius: 10px;
+      padding: 28px 32px;
+      margin-bottom: 24px;
+      border: 1px solid #1f3460;
+    }
+    .section h2 {
+      color: #7ec8e3;
+      font-size: 1.2rem;
+      margin-bottom: 12px;
+    }
+    .section p {
+      line-height: 1.7;
+      color: #c0c0d0;
+      margin-bottom: 12px;
+    }
+    .section p:last-child { margin-bottom: 0; }
+    .cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      margin-bottom: 24px;
+    }
+    .card {
+      background: #16213e;
+      border: 1px solid #1f3460;
+      border-radius: 10px;
+      padding: 32px;
+      text-decoration: none;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .card:hover {
+      border-color: #7ec8e3;
+      transform: translateY(-3px);
+    }
+    .card h3 {
+      color: #7ec8e3;
+      font-size: 1.3rem;
+      margin-bottom: 10px;
+    }
+    .card p {
+      color: #a0a0b8;
+      line-height: 1.6;
+      font-size: 0.95rem;
+    }
+    .card .arrow {
+      display: inline-block;
+      margin-top: 16px;
+      color: #7ec8e3;
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    footer {
+      text-align: center;
+      margin-top: 40px;
+      padding: 20px;
+      color: #666;
+      font-size: 13px;
+      border-top: 1px solid #1f3460;
+    }
+    footer a {
+      color: #7ec8e3;
+      text-decoration: none;
+    }
+    footer a:hover { text-decoration: underline; }
+    a { color: #7ec8e3; }
+  </style>
+</head>
+<body>
+  <div class="display-warning">⚠️ Built for 27″+ displays. Not optimized for mobile.</div>
+
+  <div class="container">
+    <h1>⚾ MLB Franchise WAR Visualizations</h1>
+    <p class="subtitle">Cumulative career WAR trajectories for every MLB franchise</p>
+
+    <div class="section">
+      <h2>What Is This?</h2>
+      <p>
+        I had the idea for this project in 2019 while playing around with FanGraph's
+        <a href="https://www.fangraphs.com/leaders/war-graphs?players=4772&wg=2">Cumulative WAR by Age</a>
+        charts. I was comparing charts for good Mariners at different positions across the team's
+        history, and thought that being able to graph them "in time" would be an interesting
+        storytelling visualization. There's no particular <em>analytical</em> value to these, but you
+        can see the peaks and troughs in a franchise's history, and there are occasional surprises
+        and interesting players that you'll find looking through the graphs.
+      </p>
+      <p>
+        I got partway into the project in 2020 before being derailed by life, as well as my own lack
+        of R skills. Luckily Copilot is good at R, and I finished my initial vision in a couple
+        weekends of work in 2026.
+      </p>
+    </div>
+
+    <div class="section">
+      <h2>Reading the Charts</h2>
+      <p>
+        These visualizations chart <strong>cumulative WAR (Wins Above Replacement)</strong> over time
+        for the top players at each MLB franchise. Each line traces a player's career value as it
+        accumulates season by season — steeper lines mean peak performance years, flat sections mean
+        missed time or league-average play. The higher a line ends, the more total value that player
+        delivered to that franchise. Of course this necessarily de-emphasizes the contributions of
+        players who moved between teams frequently, or perhaps had one or two standout seasons.
+        That is by design.
+      </p>
+      <p>
+        <strong>Z-Score Line Width:</strong> When enabled, line thickness encodes how exceptional a
+        player's WAR was <em>relative to their position and era</em>. Specifically, the width
+        represents the number of standard deviations above the league mean WAR for that
+        position-year combination. Thicker lines = more dominant seasons compared to peers at the
+        same position. Of course this correlates strongly with slope, but truly exceptional seasons
+        like Cal Raleigh's 2025 really pop.
+      </p>
+      <p>
+        <strong>Overlay Markers:</strong> Award markers can be toggled on top of the WAR lines.
+        <strong>♦ Diamonds</strong> mark MVP awards, <strong>▲ triangles</strong> mark Cy Young
+        Awards, and <strong>● dots</strong> mark All-Star selections. Postseason overlays add
+        vertical lines at each year the franchise appeared in the playoffs, providing context for
+        when teams were contending.
+      </p>
+    </div>
+
+    <div class="cards">
+      <a href="war_explorer.html" class="card">
+        <h3>Franchise WAR Grid Explorer</h3>
+        <p>
+          The 30-team grid view. See all franchises side by side, filter by position
+          (C, 1B, 2B, SS, 3B, OF, SP, RP) and era (1901–present). Toggle z-score
+          line widths, award markers, and postseason indicators.
+        </p>
+        <span class="arrow">Open Explorer →</span>
+      </a>
+
+      <a href="team_breakdown.html" class="card">
+        <h3>Team Position Breakdown</h3>
+        <p>
+          Dive into a single franchise with a 9-facet view — one panel per position.
+          Compare how a team has built value at each position over its history, with
+          linear or log scale options for the Y axis. The log scale compresses peaks,
+          but makes the low-WAR positions like relief pitcher easier to read and compare.
+        </p>
+        <span class="arrow">Open Breakdown →</span>
+      </a>
+    </div>
+
+    <div class="section">
+      <h2>Data Sources</h2>
+      <p>
+        WAR data from
+        <a href="https://www.baseball-reference.com/data/" target="_blank">Baseball Reference</a>.
+        Position classification from the
+        <a href="https://github.com/chadwickbureau/baseballdatabank" target="_blank">Lahman Database</a>.
+      </p>
+    </div>
+
+    <footer>
+      <a href="https://github.com/keownb/R-Baseball-Experiments" target="_blank">View Source on GitHub</a>
+      &nbsp;|&nbsp;
+      <a href="mailto:keownb+baseball@gmail.com">Send Feedback</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/docs/team_breakdown.html
+++ b/docs/team_breakdown.html
@@ -3,47 +3,60 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MLB Team WAR Breakdown</title>
+  <title>Team Position Breakdown — MLB WAR</title>
   <script src="https://unpkg.com/@panzoom/panzoom@4.5.1/dist/panzoom.min.js"></script>
   <style>
-    * { box-sizing: border-box; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 1600px;
-      margin: 0 auto;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      min-height: 100vh;
       padding: 20px;
-      background: #f5f5f5;
     }
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      max-width: 1600px;
+      margin: 0 auto 16px;
+      font-size: 14px;
+    }
+    .nav a {
+      color: #7ec8e3;
+      text-decoration: none;
+    }
+    .nav a:hover { text-decoration: underline; }
     h1 {
       text-align: center;
-      color: #333;
+      color: #fff;
       margin-bottom: 10px;
+      font-size: 1.6rem;
     }
     .intro {
-      background: white;
+      background: #16213e;
+      border: 1px solid #1f3460;
       border-radius: 8px;
-      padding: 20px 25px;
-      margin-bottom: 20px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      padding: 18px 24px;
+      margin: 0 auto 20px;
+      max-width: 1600px;
     }
     .intro p {
-      margin: 0 0 12px 0;
       line-height: 1.6;
-      color: #444;
+      color: #b0b0c8;
+      font-size: 0.92rem;
     }
-    .intro p:last-child { margin-bottom: 0; }
-    .intro strong { color: #222; }
     .controls {
       display: flex;
       gap: 20px;
       justify-content: center;
       align-items: flex-end;
       flex-wrap: wrap;
-      margin-bottom: 20px;
-      padding: 20px;
-      background: white;
+      margin: 0 auto 20px;
+      padding: 18px 24px;
+      background: #16213e;
+      border: 1px solid #1f3460;
       border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      max-width: 1600px;
     }
     .control-group {
       display: flex;
@@ -52,126 +65,152 @@
     }
     .control-group label {
       font-weight: 600;
-      color: #555;
-      font-size: 14px;
+      color: #8888aa;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
     }
     select {
-      padding: 10px 15px;
-      font-size: 16px;
-      border: 2px solid #ddd;
+      padding: 9px 14px;
+      font-size: 15px;
+      border: 2px solid #1f3460;
       border-radius: 6px;
-      background: white;
+      background: #0f1a36;
+      color: #e0e0e0;
       cursor: pointer;
-      min-width: 200px;
+      min-width: 180px;
     }
-    select:hover { border-color: #007bff; }
+    select:hover { border-color: #7ec8e3; }
     select:focus {
       outline: none;
-      border-color: #007bff;
-      box-shadow: 0 0 0 3px rgba(0,123,255,0.25);
+      border-color: #7ec8e3;
+      box-shadow: 0 0 0 3px rgba(126,200,227,0.2);
     }
-    .toggle-group {
-      display: flex;
-      gap: 15px;
-      align-items: center;
+    select:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
     }
-    .toggle-group label {
+    .checkbox-group {
       display: flex;
       align-items: center;
       gap: 6px;
-      cursor: pointer;
-      font-size: 14px;
-      color: #555;
+      padding: 9px 0;
     }
-    .toggle-group input[type="checkbox"] {
-      width: 18px;
-      height: 18px;
+    .checkbox-group input[type="checkbox"] {
+      width: 16px;
+      height: 16px;
+      accent-color: #7ec8e3;
       cursor: pointer;
+    }
+    .checkbox-group label {
+      font-size: 14px;
+      color: #c0c0d0;
+      cursor: pointer;
+      font-weight: 500;
     }
     .reset-btn {
-      padding: 10px 20px;
-      font-size: 14px;
-      background: #6c757d;
-      color: white;
-      border: none;
+      padding: 9px 18px;
+      font-size: 13px;
+      background: #2a2a4a;
+      color: #c0c0d0;
+      border: 2px solid #1f3460;
       border-radius: 6px;
       cursor: pointer;
+      font-weight: 600;
     }
-    .reset-btn:hover { background: #5a6268; }
+    .reset-btn:hover {
+      background: #3a3a5a;
+      border-color: #7ec8e3;
+    }
     .plot-container {
-      background: white;
+      background: #16213e;
+      border: 1px solid #1f3460;
       border-radius: 8px;
-      padding: 20px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      padding: 15px;
+      overflow: hidden;
+      max-width: 1600px;
+      margin: 0 auto;
     }
     .plot-header {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-bottom: 15px;
+      margin-bottom: 10px;
+      padding: 0 5px;
     }
     .plot-title {
-      font-size: 18px;
+      font-size: 15px;
       font-weight: 600;
-      color: #333;
+      color: #e0e0e0;
     }
     .zoom-hint {
       font-size: 12px;
-      color: #888;
+      color: #666;
     }
+    .overlay-legend {
+      background: #16213e;
+      border: 1px solid #1f3460;
+      border-radius: 8px;
+      padding: 8px 20px;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+      font-size: 13px;
+      color: #c0c0d0;
+    }
+    .legend-title { font-weight: 600; color: #7ec8e3; }
+    .legend-item { white-space: nowrap; }
+    .legend-symbol { font-size: 14px; }
+    .legend-sep { color: #444; }
     .image-wrapper {
-      overflow: hidden;
-      border: 1px solid #eee;
-      border-radius: 4px;
-      background: #fafafa;
-      max-height: 80vh;
-    }
-    .image-wrapper img {
-      display: block;
       width: 100%;
-      height: auto;
+      height: 75vh;
+      overflow: hidden;
+      cursor: grab;
+      border: 1px solid #1f3460;
+      border-radius: 4px;
+      background: #0d1321;
     }
-    .nav-links {
-      margin-top: 15px;
-      text-align: center;
-      font-size: 14px;
+    .image-wrapper:active { cursor: grabbing; }
+    .panzoom-container img {
+      width: 100%;
+      display: block;
     }
-    .nav-links a {
-      color: #007bff;
-      text-decoration: none;
-      margin: 0 10px;
-    }
-    .nav-links a:hover { text-decoration: underline; }
     footer {
       text-align: center;
-      margin-top: 30px;
+      max-width: 1600px;
+      margin: 30px auto 0;
       padding: 20px;
-      color: #888;
+      color: #555;
       font-size: 13px;
+      border-top: 1px solid #1f3460;
     }
-    footer a { color: #666; }
+    footer a {
+      color: #7ec8e3;
+      text-decoration: none;
+    }
+    footer a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
-  <h1>⚾ MLB Team WAR Breakdown</h1>
-  
+  <div class="nav" style="max-width:1600px;">
+    <div><a href="landing.html">← Back to Home</a></div>
+    <div><a href="war_explorer.html">← Grid Explorer</a></div>
+  </div>
+
+  <h1>⚾ Team Position Breakdown</h1>
+
   <div class="intro">
     <p>
-      <strong>What is this?</strong> A position-by-position breakdown of cumulative WAR for each MLB franchise.
-      Each row shows one position (C, 1B, 2B, SS, 3B, OF, DH, SP, RP) with the top 5 players highlighted
-      in the team's primary color.
-    </p>
-    <p>
-      <strong>Reading the chart:</strong> Solid team-color lines are the top 5 players by WAR at that position.
-      Secondary-color lines show the "best in gap years" — players who led the position when no top-5 player was active.
-      Gray lines show everyone else. Vertical lines mark postseason achievements.
-    </p>
-    <p>
-      <strong>Stint detection:</strong> Lines break when a player leaves and returns to the franchise,
-      so you can see separate tenures (e.g., Ken Griffey Jr.'s two stints with Seattle).
+      A per-team breakdown of cumulative WAR, split into 9 facets — one for each fielding position
+      (C, 1B, 2B, SS, 3B, OF, SP, RP, DH). See how a single franchise has built value at each
+      position across its history. Toggle between linear and log scales, z-score line widths, and
+      overlay award markers or postseason indicators.
     </p>
   </div>
-  
+
   <div class="controls">
     <div class="control-group">
       <label for="team">Team</label>
@@ -179,7 +218,7 @@
         <optgroup label="AL East">
           <option value="BAL">Baltimore Orioles</option>
           <option value="BOS">Boston Red Sox</option>
-          <option value="NYY" selected>New York Yankees</option>
+          <option value="NYY">New York Yankees</option>
           <option value="TBR">Tampa Bay Rays</option>
           <option value="TOR">Toronto Blue Jays</option>
         </optgroup>
@@ -194,7 +233,7 @@
           <option value="HOU">Houston Astros</option>
           <option value="LAA">Los Angeles Angels</option>
           <option value="OAK">Oakland Athletics</option>
-          <option value="SEA">Seattle Mariners</option>
+          <option value="SEA" selected>Seattle Mariners</option>
           <option value="TEX">Texas Rangers</option>
         </optgroup>
         <optgroup label="NL East">
@@ -220,64 +259,100 @@
         </optgroup>
       </select>
     </div>
-    
+
     <div class="control-group">
-      <label>Scale</label>
-      <div class="toggle-group">
-        <label>
-          <input type="checkbox" id="log-scale">
-          Log scale (compress high values)
-        </label>
+      <label for="scale">Scale</label>
+      <select id="scale">
+        <option value="linear">Linear</option>
+        <option value="log">Log</option>
+      </select>
+    </div>
+
+    <div class="control-group">
+      <label for="line-width">Line Width</label>
+      <select id="line-width">
+        <option value="const">Constant</option>
+        <option value="zscore">Z-Score</option>
+      </select>
+    </div>
+
+    <div class="control-group">
+      <label>&nbsp;</label>
+      <div class="checkbox-group">
+        <input type="checkbox" id="awards">
+        <label for="awards">Awards</label>
       </div>
     </div>
-    
+
+    <div class="control-group">
+      <label>&nbsp;</label>
+      <div class="checkbox-group">
+        <input type="checkbox" id="postseason">
+        <label for="postseason">Postseason</label>
+      </div>
+    </div>
+
     <button class="reset-btn" id="reset-zoom">Reset Zoom</button>
   </div>
-  
+
+  <div class="overlay-legend" id="overlay-legend" style="display:none;">
+    <span class="legend-title">Legend:</span>
+    <span class="legend-item"><span class="legend-symbol" style="color:#FFD700;">◆</span> MVP</span>
+    <span class="legend-item"><span class="legend-symbol" style="color:#FFD700;">▲</span> Cy Young</span>
+    <span class="legend-item"><span class="legend-symbol" style="color:#CCCCCC;">●</span> All-Star</span>
+    <span class="legend-sep">|</span>
+    <span class="legend-item"><span style="border-bottom:2px solid #FFD700;">——</span> World Series</span>
+    <span class="legend-item"><span style="border-bottom:2px dashed #87CEEB;">– –</span> LCS</span>
+    <span class="legend-item"><span style="border-bottom:2px dotted #90EE90;">···</span> Div Series</span>
+    <span class="legend-item"><span style="border-bottom:2px dashed #DDA0DD;">-·-</span> Wild Card</span>
+  </div>
+
   <div class="plot-container">
     <div class="plot-header">
-      <div class="plot-title" id="plot-title">New York Yankees — Cumulative WAR by Position</div>
-      <div class="zoom-hint">🔍 Scroll to zoom • Drag to pan</div>
+      <div class="plot-title" id="plot-title">Seattle Mariners — Position Breakdown (Linear, Constant Width)</div>
+      <div class="zoom-hint">🔍 Scroll to zoom · Drag to pan</div>
     </div>
     <div class="image-wrapper" id="image-wrapper">
-      <img id="plot-image" src="team_breakdowns/NYY_linear.png" alt="Team WAR Breakdown">
-    </div>
-    <div class="nav-links">
-      <a href="war_explorer.html">← Back to 30-Team Explorer</a>
+      <div class="panzoom-container" id="panzoom-container">
+        <img id="plot-image" src="team_breakdowns/SEA_linear_const.png" alt="Team Breakdown Plot" style="width:100%; display:block;">
+      </div>
     </div>
   </div>
 
   <footer>
-    Data: <a href="https://www.baseball-reference.com/data/" target="_blank">Baseball Reference WAR</a> |
-    Position data: <a href="https://github.com/chadwickbureau/baseballdatabank" target="_blank">Lahman Database</a> |
+    Data: <a href="https://www.baseball-reference.com/data/" target="_blank">Baseball Reference WAR</a> ·
+    Position data: <a href="https://github.com/chadwickbureau/baseballdatabank" target="_blank">Lahman Database</a> ·
     <a href="https://github.com/keownb/R-Baseball-Experiments" target="_blank">Source Code</a>
   </footer>
 
   <script>
     const teamNames = {
-      'BAL': 'Baltimore Orioles', 'BOS': 'Boston Red Sox', 'NYY': 'New York Yankees',
-      'TBR': 'Tampa Bay Rays', 'TOR': 'Toronto Blue Jays', 'CHW': 'Chicago White Sox',
-      'CLE': 'Cleveland Guardians', 'DET': 'Detroit Tigers', 'KCR': 'Kansas City Royals',
-      'MIN': 'Minnesota Twins', 'HOU': 'Houston Astros', 'LAA': 'Los Angeles Angels',
-      'OAK': 'Oakland Athletics', 'SEA': 'Seattle Mariners', 'TEX': 'Texas Rangers',
-      'ATL': 'Atlanta Braves', 'MIA': 'Miami Marlins', 'NYM': 'New York Mets',
-      'PHI': 'Philadelphia Phillies', 'WSN': 'Washington Nationals', 'CHC': 'Chicago Cubs',
-      'CIN': 'Cincinnati Reds', 'MIL': 'Milwaukee Brewers', 'PIT': 'Pittsburgh Pirates',
-      'STL': 'St. Louis Cardinals', 'ARI': 'Arizona Diamondbacks', 'COL': 'Colorado Rockies',
-      'LAD': 'Los Angeles Dodgers', 'SDP': 'San Diego Padres', 'SFG': 'San Francisco Giants'
+      BAL: 'Baltimore Orioles', BOS: 'Boston Red Sox', NYY: 'New York Yankees',
+      TBR: 'Tampa Bay Rays', TOR: 'Toronto Blue Jays', CHW: 'Chicago White Sox',
+      CLE: 'Cleveland Guardians', DET: 'Detroit Tigers', KCR: 'Kansas City Royals',
+      MIN: 'Minnesota Twins', HOU: 'Houston Astros', LAA: 'Los Angeles Angels',
+      OAK: 'Oakland Athletics', SEA: 'Seattle Mariners', TEX: 'Texas Rangers',
+      ATL: 'Atlanta Braves', MIA: 'Miami Marlins', NYM: 'New York Mets',
+      PHI: 'Philadelphia Phillies', WSN: 'Washington Nationals', CHC: 'Chicago Cubs',
+      CIN: 'Cincinnati Reds', MIL: 'Milwaukee Brewers', PIT: 'Pittsburgh Pirates',
+      STL: 'St. Louis Cardinals', ARI: 'Arizona Diamondbacks', COL: 'Colorado Rockies',
+      LAD: 'Los Angeles Dodgers', SDP: 'San Diego Padres', SFG: 'San Francisco Giants'
     };
 
     const teamSelect = document.getElementById('team');
-    const logScaleCheckbox = document.getElementById('log-scale');
+    const scaleSelect = document.getElementById('scale');
+    const widthSelect = document.getElementById('line-width');
+    const awardsCheck = document.getElementById('awards');
+    const postseasonCheck = document.getElementById('postseason');
     const plotImage = document.getElementById('plot-image');
     const plotTitle = document.getElementById('plot-title');
-    const imageWrapper = document.getElementById('image-wrapper');
     const resetBtn = document.getElementById('reset-zoom');
+    const panzoomContainer = document.getElementById('panzoom-container');
+    const imageWrapper = document.getElementById('image-wrapper');
 
-    // Initialize Panzoom
-    const panzoom = Panzoom(plotImage, {
+    const panzoom = Panzoom(panzoomContainer, {
       maxScale: 5,
-      minScale: 0.3,
+      minScale: 0.5,
       contain: 'outside'
     });
     imageWrapper.addEventListener('wheel', panzoom.zoomWithWheel);
@@ -289,26 +364,44 @@
 
     function updatePlot() {
       const team = teamSelect.value;
-      const scale = logScaleCheckbox.checked ? 'log' : 'linear';
-      
-      const filename = `team_breakdowns/${team}_${scale}.png`;
-      plotImage.src = filename;
-      
+      const scale = scaleSelect.value;
+      const width = widthSelect.value;
+      const showAwards = awardsCheck.checked;
+      const showPostseason = postseasonCheck.checked;
+
+      // Build filename: {TEAM}_{scale}_{width}[_awards|_postseason|_all].png
+      let fname = `${team}_${scale}_${width}`;
+      if (showAwards && showPostseason) {
+        fname += '_all';
+      } else if (showAwards) {
+        fname += '_awards';
+      } else if (showPostseason) {
+        fname += '_postseason';
+      }
+      plotImage.src = `team_breakdowns/${fname}.png`;
       plotImage.onload = resetZoom;
-      
-      const teamName = teamNames[team] || team;
-      const scaleLabel = logScaleCheckbox.checked ? ' (Log Scale)' : '';
-      plotTitle.textContent = `${teamName} — Cumulative WAR by Position${scaleLabel}`;
+
+      // Title
+      const name = teamNames[team] || team;
+      const scaleLabel = scale === 'linear' ? 'Linear' : 'Log';
+      const widthLabel = width === 'const' ? 'Constant Width' : 'Z-Score Width';
+      plotTitle.textContent = `${name} — Position Breakdown (${scaleLabel}, ${widthLabel})`;
+
+      // Show legend when any overlay feature is active
+      document.getElementById('overlay-legend').style.display =
+        (showAwards || showPostseason) ? 'flex' : 'none';
     }
 
     teamSelect.addEventListener('change', updatePlot);
-    logScaleCheckbox.addEventListener('change', updatePlot);
-    
+    scaleSelect.addEventListener('change', updatePlot);
+    widthSelect.addEventListener('change', updatePlot);
+    awardsCheck.addEventListener('change', updatePlot);
+    postseasonCheck.addEventListener('change', updatePlot);
+
     plotImage.addEventListener('error', function() {
-      this.alt = 'Chart not yet generated. Run generate_team_breakdowns.R first.';
+      this.alt = 'Plot not yet generated. Run the R scripts first.';
     });
 
-    // Initialize
     updatePlot();
   </script>
 </body>

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -6,44 +6,64 @@
   <title>MLB Franchise WAR Explorer</title>
   <script src="https://unpkg.com/@panzoom/panzoom@4.5.1/dist/panzoom.min.js"></script>
   <style>
-    * { box-sizing: border-box; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      max-width: 1600px;
-      margin: 0 auto;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      min-height: 100vh;
       padding: 20px;
-      background: #f5f5f5;
     }
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      max-width: 1600px;
+      margin: 0 auto 16px;
+      font-size: 14px;
+    }
+    .nav a {
+      color: #7ec8e3;
+      text-decoration: none;
+    }
+    .nav a:hover { text-decoration: underline; }
     h1 {
       text-align: center;
-      color: #333;
+      color: #fff;
       margin-bottom: 10px;
+      font-size: 1.6rem;
+      max-width: 1600px;
+      margin-left: auto;
+      margin-right: auto;
     }
     .intro {
-      background: white;
+      background: #16213e;
+      border: 1px solid #1f3460;
       border-radius: 8px;
-      padding: 20px 25px;
-      margin-bottom: 20px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      padding: 18px 24px;
+      margin: 0 auto 20px;
+      max-width: 1600px;
     }
     .intro p {
       margin: 0 0 12px 0;
       line-height: 1.6;
-      color: #444;
+      color: #b0b0c8;
+      font-size: 0.92rem;
     }
     .intro p:last-child { margin-bottom: 0; }
-    .intro strong { color: #222; }
+    .intro strong { color: #e0e0e0; }
+    .intro a { color: #7ec8e3; }
     .controls {
       display: flex;
       gap: 20px;
       justify-content: center;
       align-items: flex-end;
       flex-wrap: wrap;
-      margin-bottom: 20px;
-      padding: 20px;
-      background: white;
+      margin: 0 auto 20px;
+      padding: 18px 24px;
+      background: #16213e;
+      border: 1px solid #1f3460;
       border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      max-width: 1600px;
     }
     .control-group {
       display: flex;
@@ -52,44 +72,71 @@
     }
     .control-group label {
       font-weight: 600;
-      color: #555;
-      font-size: 14px;
+      color: #8888aa;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
     }
     select {
-      padding: 10px 15px;
-      font-size: 16px;
-      border: 2px solid #ddd;
+      padding: 9px 14px;
+      font-size: 15px;
+      border: 2px solid #1f3460;
       border-radius: 6px;
-      background: white;
+      background: #0f1a36;
+      color: #e0e0e0;
       cursor: pointer;
       min-width: 180px;
     }
-    select:hover { border-color: #007bff; }
+    select:hover { border-color: #7ec8e3; }
     select:focus {
       outline: none;
-      border-color: #007bff;
-      box-shadow: 0 0 0 3px rgba(0,123,255,0.25);
+      border-color: #7ec8e3;
+      box-shadow: 0 0 0 3px rgba(126,200,227,0.2);
     }
     select:disabled {
-      opacity: 0.5;
+      opacity: 0.4;
       cursor: not-allowed;
     }
-    .reset-btn {
-      padding: 10px 20px;
-      font-size: 14px;
-      background: #6c757d;
-      color: white;
-      border: none;
-      border-radius: 6px;
+    .checkbox-group {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 9px 0;
+    }
+    .checkbox-group input[type="checkbox"] {
+      width: 16px;
+      height: 16px;
+      accent-color: #7ec8e3;
       cursor: pointer;
     }
-    .reset-btn:hover { background: #5a6268; }
+    .checkbox-group label {
+      font-size: 14px;
+      color: #c0c0d0;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    .reset-btn {
+      padding: 9px 18px;
+      font-size: 13px;
+      background: #2a2a4a;
+      color: #c0c0d0;
+      border: 2px solid #1f3460;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .reset-btn:hover {
+      background: #3a3a5a;
+      border-color: #7ec8e3;
+    }
     .plot-container {
-      background: white;
+      background: #16213e;
+      border: 1px solid #1f3460;
       border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
       padding: 15px;
       overflow: hidden;
+      max-width: 1600px;
+      margin: 0 auto;
     }
     .plot-header {
       display: flex;
@@ -99,35 +146,51 @@
       padding: 0 5px;
     }
     .plot-title {
-      font-size: 16px;
+      font-size: 15px;
       font-weight: 600;
-      color: #333;
+      color: #e0e0e0;
     }
     .zoom-hint {
       font-size: 12px;
-      color: #888;
+      color: #666;
     }
+    .overlay-legend {
+      background: #16213e;
+      border: 1px solid #1f3460;
+      border-radius: 8px;
+      padding: 8px 20px;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+      font-size: 13px;
+      color: #c0c0d0;
+    }
+    .legend-title { font-weight: 600; color: #7ec8e3; }
+    .legend-item { white-space: nowrap; }
+    .legend-symbol { font-size: 14px; }
+    .legend-sep { color: #444; }
     .image-wrapper {
       width: 100%;
       height: 70vh;
       overflow: hidden;
       cursor: grab;
-      border: 1px solid #eee;
+      border: 1px solid #1f3460;
       border-radius: 4px;
-      background: #fafafa;
+      background: #0d1321;
     }
     .image-wrapper:active { cursor: grabbing; }
-    .image-wrapper img {
+    .panzoom-container img {
       width: 100%;
-      height: auto;
       display: block;
     }
     .era-info {
       font-size: 13px;
-      color: #666;
+      color: #8888aa;
       margin-top: 12px;
       padding: 10px 15px;
-      background: #f8f9fa;
+      background: #0f1a36;
       border-radius: 4px;
     }
     .data-link {
@@ -135,21 +198,32 @@
       font-size: 12px;
     }
     .data-link a {
-      color: #007bff;
+      color: #7ec8e3;
       text-decoration: none;
     }
     .data-link a:hover { text-decoration: underline; }
     footer {
       text-align: center;
-      margin-top: 30px;
+      max-width: 1600px;
+      margin: 30px auto 0;
       padding: 20px;
-      color: #888;
+      color: #555;
       font-size: 13px;
+      border-top: 1px solid #1f3460;
     }
-    footer a { color: #666; }
+    footer a {
+      color: #7ec8e3;
+      text-decoration: none;
+    }
+    footer a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
+  <div class="nav" style="max-width:1600px;">
+    <div><a href="landing.html">← Back to Home</a></div>
+    <div><a href="team_breakdown.html">Team Breakdown →</a></div>
+  </div>
+
   <h1>⚾ MLB Franchise WAR Explorer</h1>
   
   <div class="intro">
@@ -203,28 +277,65 @@
         <option value="1998">1998 — ARI/TBR (30 Teams)</option>
       </select>
     </div>
+
+    <div class="control-group">
+      <label for="line-width">Line Width</label>
+      <select id="line-width">
+        <option value="constant">Constant</option>
+        <option value="zscore">Z-Score</option>
+      </select>
+    </div>
+
+    <div class="control-group">
+      <label>&nbsp;</label>
+      <div class="checkbox-group">
+        <input type="checkbox" id="awards">
+        <label for="awards">Awards</label>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label>&nbsp;</label>
+      <div class="checkbox-group">
+        <input type="checkbox" id="postseason">
+        <label for="postseason">Postseason</label>
+      </div>
+    </div>
     
     <button class="reset-btn" id="reset-zoom">Reset Zoom</button>
+  </div>
+
+  <div class="overlay-legend" id="overlay-legend" style="display:none;">
+    <span class="legend-title">Legend:</span>
+    <span class="legend-item"><span class="legend-symbol" style="color:#FFD700;">◆</span> MVP</span>
+    <span class="legend-item"><span class="legend-symbol" style="color:#FFD700;">▲</span> Cy Young</span>
+    <span class="legend-item"><span class="legend-symbol" style="color:#CCCCCC;">●</span> All-Star</span>
+    <span class="legend-sep">|</span>
+    <span class="legend-item"><span style="border-bottom:2px solid #FFD700;">——</span> World Series</span>
+    <span class="legend-item"><span style="border-bottom:2px dashed #87CEEB;">– –</span> LCS</span>
+    <span class="legend-item"><span style="border-bottom:2px dotted #90EE90;">···</span> Div Series</span>
+    <span class="legend-item"><span style="border-bottom:2px dashed #DDA0DD;">-·-</span> Wild Card</span>
   </div>
   
   <div class="plot-container">
     <div class="plot-header">
-      <div class="plot-title" id="plot-title">Cumulative WAR by Franchise — Position Players (1901-Present)</div>
-      <div class="zoom-hint">🔍 Scroll to zoom • Drag to pan</div>
+      <div class="plot-title" id="plot-title">Cumulative WAR by Franchise — All Players (1901-Present)</div>
+      <div class="zoom-hint">🔍 Scroll to zoom · Drag to pan</div>
     </div>
     <div class="image-wrapper" id="image-wrapper">
-      <img id="plot-image" src="plots/batters_all_1901.png" alt="WAR Plot">
+      <div class="panzoom-container" id="panzoom-container">
+        <img id="plot-image" src="plots/all_1901.png" alt="WAR Plot" style="width:100%; display:block;">
+      </div>
     </div>
     <div class="era-info" id="era-info"></div>
     <div class="data-link">
-      📊 <a href="#" id="csv-link" target="_blank">Download data (CSV)</a> |
-      🔍 <a href="team_breakdown.html">Team Position Breakdown →</a>
+      📊 <a href="#" id="csv-link" target="_blank">Download data (CSV)</a>
     </div>
   </div>
 
   <footer>
-    Data: <a href="https://www.baseball-reference.com/data/" target="_blank">Baseball Reference WAR</a> |
-    Position data: <a href="https://github.com/chadwickbureau/baseballdatabank" target="_blank">Lahman Database</a> |
+    Data: <a href="https://www.baseball-reference.com/data/" target="_blank">Baseball Reference WAR</a> ·
+    Position data: <a href="https://github.com/chadwickbureau/baseballdatabank" target="_blank">Lahman Database</a> ·
     <a href="https://github.com/keownb/R-Baseball-Experiments" target="_blank">Source Code</a>
   </footer>
 
@@ -252,17 +363,24 @@
       'rp': 'Relief Pitchers (RP)'
     };
 
+    // Positions that support z-score width
+    const singlePositions = new Set(['c', '1b', '2b', 'ss', '3b', 'of', 'sp', 'rp']);
+
     const positionSelect = document.getElementById('position');
     const eraSelect = document.getElementById('era');
+    const widthSelect = document.getElementById('line-width');
+    const awardsCheck = document.getElementById('awards');
+    const postseasonCheck = document.getElementById('postseason');
     const plotImage = document.getElementById('plot-image');
     const plotTitle = document.getElementById('plot-title');
     const eraInfoDiv = document.getElementById('era-info');
     const csvLink = document.getElementById('csv-link');
     const imageWrapper = document.getElementById('image-wrapper');
+    const panzoomContainer = document.getElementById('panzoom-container');
     const resetBtn = document.getElementById('reset-zoom');
 
-    // Initialize Panzoom
-    const panzoom = Panzoom(plotImage, {
+    // Initialize Panzoom on the container so all layers zoom/pan together
+    const panzoom = Panzoom(panzoomContainer, {
       maxScale: 5,
       minScale: 0.5,
       contain: 'outside'
@@ -270,21 +388,46 @@
     imageWrapper.addEventListener('wheel', panzoom.zoomWithWheel);
     resetBtn.addEventListener('click', () => panzoom.reset());
 
-    // Reset zoom when image changes
     function resetZoom() {
       panzoom.reset({ animate: false });
+    }
+
+    // Enforce z-score availability based on position selection
+    function updateWidthAvailability() {
+      const pos = positionSelect.value;
+      if (!singlePositions.has(pos)) {
+        widthSelect.value = 'constant';
+        widthSelect.disabled = true;
+      } else {
+        widthSelect.disabled = false;
+      }
     }
 
     function updatePlot() {
       const position = positionSelect.value;
       const era = eraSelect.value;
+      const showAwards = awardsCheck.checked;
+      const showPostseason = postseasonCheck.checked;
       
-      // Build filename - now just position_era.png
-      const baseName = `${position}_${era}`;
-      
-      // Update image and CSV link
-      plotImage.src = `plots/${baseName}.png`;
-      csvLink.href = `data/${baseName}.csv`;
+      updateWidthAvailability();
+      const effectiveWidth = widthSelect.value;
+
+      // Build filename: {pos}_{era}[_zscore][_awards|_postseason|_all].png
+      let fname = `${position}_${era}`;
+      if (effectiveWidth === 'zscore' && singlePositions.has(position)) {
+        fname += '_zscore';
+      }
+      if (showAwards && showPostseason) {
+        fname += '_all';
+      } else if (showAwards) {
+        fname += '_awards';
+      } else if (showPostseason) {
+        fname += '_postseason';
+      }
+      plotImage.src = `plots/${fname}.png`;
+
+      // CSV link (base name only)
+      csvLink.href = `data/${position}_${era}.csv`;
       
       // Reset zoom on new image
       plotImage.onload = resetZoom;
@@ -295,10 +438,17 @@
       
       // Update era info
       eraInfoDiv.textContent = eraInfo[era];
+
+      // Show legend when any overlay feature is active
+      document.getElementById('overlay-legend').style.display =
+        (showAwards || showPostseason) ? 'flex' : 'none';
     }
 
     positionSelect.addEventListener('change', updatePlot);
     eraSelect.addEventListener('change', updatePlot);
+    widthSelect.addEventListener('change', updatePlot);
+    awardsCheck.addEventListener('change', updatePlot);
+    postseasonCheck.addEventListener('change', updatePlot);
     
     // Handle image load errors
     plotImage.addEventListener('error', function() {

--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -426,7 +426,7 @@ generate_franchise_war_plot <- function(
     scale_color_manual(values = primary_colors, guide = "none") +
     scale_x_continuous(breaks = x_breaks) +
     ggh4x::facet_wrap2(~ reorder(franchise, div_order), ncol = 5, axes = "x") +
-    coord_cartesian(xlim = c(start_year, 2026), ylim = c(0, 175)) +
+    coord_cartesian(xlim = c(start_year, 2026), ylim = c(0, ceiling(max(top_plot_data$cumWAR_franchise, na.rm = TRUE) * 1.1 / 5) * 5)) +
     theme_minimal() +
     theme(
       legend.position = "top",
@@ -623,38 +623,4 @@ get_postseason_data <- function(team_code) {
 # Save a transparent overlay PNG that is pixel-aligned with the base plot.
 # Builds an overlay plot using the same scales/facets/coords/dimensions,
 # but with transparent backgrounds and invisible text (preserving spacing).
-save_overlay_png <- function(overlay_layers, base_plot, filename,
-                             width, height, dpi = 150) {
-  # Extract the base plot's scales, facet, coord, and theme
-  p_overlay <- base_plot
-  
-  # Remove all existing layers from the base
-  p_overlay$layers <- list()
-  
-  # Add only the overlay layers
-  for (layer in overlay_layers) {
-    p_overlay <- p_overlay + layer
-  }
-  
-  # Make everything transparent except the overlay marks
-  p_overlay <- p_overlay +
-    theme(
-      panel.background = element_rect(fill = "transparent", color = NA),
-      plot.background = element_rect(fill = "transparent", color = NA),
-      panel.grid.major = element_blank(),
-      panel.grid.minor = element_blank(),
-      axis.text = element_text(color = "transparent"),
-      axis.title = element_text(color = "transparent"),
-      axis.ticks = element_line(color = "transparent"),
-      strip.text = element_text(color = "transparent"),
-      strip.background = element_rect(fill = "transparent", color = NA),
-      plot.title = element_text(color = "transparent"),
-      plot.subtitle = element_text(color = "transparent"),
-      plot.caption = element_text(color = "transparent"),
-      legend.position = "none"
-    )
-  
-  ggsave(filename, plot = p_overlay, width = width, height = height,
-         dpi = dpi, bg = "transparent")
-  message(sprintf("  Overlay saved: %s", filename))
-}
+

--- a/generate_all_plots.R
+++ b/generate_all_plots.R
@@ -57,16 +57,21 @@ award_data <- load_award_data()
 # GENERATE ALL PLOTS
 # =============================================================================
 
-# For each position × era, generate:
-#   1. Base constant-width PNG
-#   2. Base z-score-width PNG (single positions only)
-#   3. Awards overlay (transparent)
-#   4. Postseason overlay (transparent)
-#   5. CSV data export
+# For each position × era, generate all overlay combos as full pre-rendered images.
+# Naming: {pos}_{era}[_zscore][_awards|_postseason|_all].png
+# This avoids overlay alignment issues — each image is self-contained.
+
+OVERLAY_COMBOS <- list(
+  list(suffix = "",            awards = FALSE, postseason = FALSE),
+  list(suffix = "_awards",     awards = TRUE,  postseason = FALSE),
+  list(suffix = "_postseason", awards = FALSE, postseason = TRUE),
+  list(suffix = "_all",        awards = TRUE,  postseason = TRUE)
+)
 
 n_positions <- length(POSITIONS)
 n_eras <- length(ERAS)
 current <- 0
+total <- n_positions * n_eras
 
 message(sprintf("\n=== Generating plots for %d positions × %d eras ===\n", n_positions, n_eras))
 
@@ -84,49 +89,30 @@ for (era in ERAS) {
       "batting" = "Position Players", "pitching" = "Pitchers", "combined" = "All Players")
     
     base_name <- sprintf("%s_%d", tolower(pos_name), era)
-    message(sprintf("[%d/%d] %s", current, n_positions * n_eras, base_name))
+    message(sprintf("[%d/%d] %s", current, total, base_name))
     
-    # --- 1. Constant-width base ---
-    p_const <- generate_franchise_war_plot(
-      war_source, type_label, start_year = era, position_filter = pos_filter)
-    ggsave(sprintf("%s/%s.png", OUTPUT_DIR, base_name),
-           plot = p_const, width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
-    export_plot_data(p_const, sprintf("%s/%s.csv", DATA_DIR, base_name))
-    
-    # --- 2. Z-score-width base (single positions only) ---
+    width_modes <- list(list(name = "", vw = FALSE, stats = NULL))
     if (can_zscore) {
-      p_zscore <- generate_franchise_war_plot(
-        war_source, type_label, start_year = era, position_filter = pos_filter,
-        variable_width = TRUE, pos_year_stats = pos_year_stats)
-      ggsave(sprintf("%s/%s_zscore.png", OUTPUT_DIR, base_name),
-             plot = p_zscore, width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+      width_modes[[2]] <- list(name = "_zscore", vw = TRUE, stats = pos_year_stats)
     }
     
-    # --- 3. Awards overlay ---
-    p_awards <- generate_franchise_war_plot(
-      war_source, type_label, start_year = era, position_filter = pos_filter,
-      show_awards = TRUE, award_data = award_data)
-    award_layer <- p_awards$layers[sapply(p_awards$layers, function(l) {
-      inherits(l$geom, "GeomPoint")
-    })]
-    if (length(award_layer) > 0) {
-      save_overlay_png(award_layer, p_const,
-        sprintf("%s/%s_awards.png", OUTPUT_DIR, base_name),
-        width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+    for (wm in width_modes) {
+      for (oc in OVERLAY_COMBOS) {
+        fname <- sprintf("%s/%s%s%s.png", OUTPUT_DIR, base_name, wm$name, oc$suffix)
+        
+        p <- generate_franchise_war_plot(
+          war_source, type_label, start_year = era, position_filter = pos_filter,
+          variable_width = wm$vw, pos_year_stats = wm$stats,
+          show_awards = oc$awards, award_data = if (oc$awards) award_data else NULL,
+          show_postseason = oc$postseason)
+        ggsave(fname, plot = p, width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
+      }
     }
     
-    # --- 4. Postseason overlay ---
-    p_post <- generate_franchise_war_plot(
-      war_source, type_label, start_year = era, position_filter = pos_filter,
-      show_postseason = TRUE)
-    post_layer <- p_post$layers[sapply(p_post$layers, function(l) {
-      inherits(l$geom, "GeomVline")
-    })]
-    if (length(post_layer) > 0) {
-      save_overlay_png(post_layer, p_const,
-        sprintf("%s/%s_postseason.png", OUTPUT_DIR, base_name),
-        width = PLOT_WIDTH, height = PLOT_HEIGHT, dpi = PLOT_DPI)
-    }
+    # CSV export (just the base data, once per position/era)
+    p_csv <- generate_franchise_war_plot(
+      war_source, type_label, start_year = era, position_filter = pos_filter)
+    export_plot_data(p_csv, sprintf("%s/%s.csv", DATA_DIR, base_name))
   }
 }
 

--- a/generate_team_breakdowns.R
+++ b/generate_team_breakdowns.R
@@ -48,16 +48,23 @@ award_data <- load_award_data()
 # BATCH GENERATE
 # =============================================================================
 
-# Per team: 2 scales × 2 widths = 4 base PNGs + 2 award overlays + 2 postseason overlays = 8
-# 30 teams × 8 = 240 total
+# Per team: 2 scales × 2 widths × 4 overlay combos = 16 images
+# 30 teams × 16 = 480 total
+
+OVERLAY_COMBOS <- list(
+  list(suffix = "",            awards = FALSE, postseason = FALSE),
+  list(suffix = "_awards",     awards = TRUE,  postseason = FALSE),
+  list(suffix = "_postseason", awards = FALSE, postseason = TRUE),
+  list(suffix = "_all",        awards = TRUE,  postseason = TRUE)
+)
 
 n_teams <- length(TEAMS)
 scales <- c("linear", "log")
 widths <- c("const", "zscore")
+total <- n_teams * length(scales) * length(widths) * length(OVERLAY_COMBOS)
 current <- 0
-total <- n_teams * length(scales) * (length(widths) + 2)  # bases + overlays
 
-message(sprintf("\n=== Generating ~%d team breakdown images ===\n", total))
+message(sprintf("\n=== Generating %d team breakdown images ===\n", total))
 
 for (team_code in names(TEAMS)) {
   team_name <- TEAMS[[team_code]]
@@ -67,76 +74,29 @@ for (team_code in names(TEAMS)) {
     
     for (width_name in widths) {
       is_zscore <- width_name == "zscore"
-      current <- current + 1
       
-      fname <- sprintf("%s/%s_%s_%s.png", OUTPUT_DIR, team_code, scale_name, width_name)
-      message(sprintf("[%d/%d] %s %s %s", current, total, team_code, scale_name, width_name))
-      
-      p <- generate_team_position_plot(
-        WAR_bat, WAR_pitch,
-        team_code = team_code, team_name = team_name,
-        show_postseason = TRUE,
-        log_scale = is_log,
-        variable_width = is_zscore,
-        pos_year_stats = if (is_zscore) pos_year_stats else NULL
-      )
-      
-      n_pos <- attr(p, "n_positions")
-      plot_height <- 3 * n_pos + 2
-      ggsave(fname, plot = p, width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
-    }
-    
-    # --- Award overlay (one per scale) ---
-    current <- current + 1
-    message(sprintf("[%d/%d] %s %s awards overlay", current, total, team_code, scale_name))
-    
-    p_awards <- generate_team_position_plot(
-      WAR_bat, WAR_pitch,
-      team_code = team_code, team_name = team_name,
-      log_scale = is_log,
-      show_awards = TRUE, award_data = award_data
-    )
-    
-    n_pos <- attr(p_awards, "n_positions")
-    plot_height <- 3 * n_pos + 2
-    
-    award_layers <- p_awards$layers[sapply(p_awards$layers, function(l) {
-      inherits(l$geom, "GeomPoint")
-    })]
-    
-    # Use the constant-width base as reference for overlay alignment
-    p_ref <- generate_team_position_plot(
-      WAR_bat, WAR_pitch,
-      team_code = team_code, team_name = team_name,
-      show_postseason = TRUE, log_scale = is_log
-    )
-    
-    if (length(award_layers) > 0) {
-      save_overlay_png(award_layers, p_ref,
-        sprintf("%s/%s_%s_awards.png", OUTPUT_DIR, team_code, scale_name),
-        width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
-    }
-    
-    # --- Postseason overlay (one per scale) ---
-    current <- current + 1
-    message(sprintf("[%d/%d] %s %s postseason overlay", current, total, team_code, scale_name))
-    
-    p_post <- generate_team_position_plot(
-      WAR_bat, WAR_pitch,
-      team_code = team_code, team_name = team_name,
-      show_postseason = TRUE, log_scale = is_log
-    )
-    
-    post_layers <- p_post$layers[sapply(p_post$layers, function(l) {
-      inherits(l$geom, "GeomVline")
-    })]
-    
-    if (length(post_layers) > 0) {
-      save_overlay_png(post_layers, p_ref,
-        sprintf("%s/%s_%s_postseason.png", OUTPUT_DIR, team_code, scale_name),
-        width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
+      for (oc in OVERLAY_COMBOS) {
+        current <- current + 1
+        fname <- sprintf("%s/%s_%s_%s%s.png", OUTPUT_DIR, team_code, scale_name, width_name, oc$suffix)
+        message(sprintf("[%d/%d] %s", current, total, basename(fname)))
+        
+        p <- generate_team_position_plot(
+          WAR_bat, WAR_pitch,
+          team_code = team_code, team_name = team_name,
+          show_postseason = oc$postseason,
+          log_scale = is_log,
+          variable_width = is_zscore,
+          pos_year_stats = if (is_zscore) pos_year_stats else NULL,
+          show_awards = oc$awards,
+          award_data = if (oc$awards) award_data else NULL
+        )
+        
+        n_pos <- attr(p, "n_positions")
+        plot_height <- 3 * n_pos + 2
+        ggsave(fname, plot = p, width = PLOT_WIDTH, height = plot_height, dpi = PLOT_DPI)
+      }
     }
   }
 }
 
-message(sprintf("\n=== Done! Generated images in %s ===", OUTPUT_DIR))
+message(sprintf("\n=== Done! Generated %d images in %s ===", total, OUTPUT_DIR))


### PR DESCRIPTION
## Summary

Replaces the fragile transparent overlay approach with full pre-rendered images. Each toggle combination gets its own self-contained image — no alignment issues possible.

### Changes (6 files)

**R code:**
- Removed `save_overlay_png()` from `franchise_war_functions.R`
- Dynamic y-axis scaling (fits actual data instead of hardcoded 175)
- `generate_all_plots.R`: generates 4 full image variants per position×era
- `generate_team_breakdowns.R`: generates 4 variants per team×scale×width

**HTML:**
- `war_explorer.html`: swaps `img src` instead of stacking overlays
- `team_breakdown.html`: same simplification
- `landing.html`: new project intro page (27"+ display notice, feedback link)

### Image naming convention
- Grid: `{pos}_{era}[_zscore][_awards|_postseason|_all].png`
- Breakdown: `{TEAM}_{scale}_{width}[_awards|_postseason|_all].png`

**Note:** 936 PNGs (~987 MB) will be pushed directly to master after this merges.
