### PR TITLE
Fix rendering device and team colors

### DIFF
--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -78,7 +78,7 @@ team_colors <- tribble(
   "LAA", "#BA0021", "#003263",
   "HOU", "#EB6E1F", "#002D62",
   "OAK", "#003831", "#EFB21E",
-  "SEA", "#005C5C", "#8FBCBB",
+  "SEA", "#005C5C", "#8A8D8F",
   "TEX", "#003278", "#C0111F",
   # AL Central
   "CHW", "#27251F", "#888888",
@@ -94,7 +94,7 @@ team_colors <- tribble(
   "TOR", "#134A8E", "#629DD1",
   # NL West
   "ARI", "#A71930", "#C49B6A",
-  "COL", "#6B5B95", "#C0B3D9",
+  "COL", "#6B5B95", "#9B8BB4",
   "LAD", "#005A9C", "#7A8B8B",
   "SDP", "#FFC425", "#2F241D",
   "SFG", "#FD5A1E", "#27251F",

--- a/generate_all_plots.R
+++ b/generate_all_plots.R
@@ -47,8 +47,6 @@ WAR_combined <- bind_rows(WAR_bat %>% select(all_of(common_cols)),
 message("=== Loading shared data ===")
 pos_year_stats <- compute_position_year_stats(WAR_bat, WAR_pitch)
 award_data <- load_award_data()
-use_ragg <- requireNamespace("ragg", quietly = TRUE)
-
 jobs <- list()
 for (era in ERAS) {
   for (pos_name in names(POSITIONS)) {
@@ -71,21 +69,20 @@ for (era in ERAS) {
   }
 }
 
-message(sprintf("\n=== %d items | %d cores | %s ===\n", length(jobs), N_CORES, if(use_ragg)"ragg"else"png"))
+message(sprintf("\n=== %d items | %d cores ===\n", length(jobs), N_CORES))
 
 # Chunk jobs across cores and use parLapply (PSOCK cluster = separate processes)
 cl <- parallel::makeCluster(N_CORES)
 
 # Export everything workers need
 parallel::clusterExport(cl, c("WAR_bat","WAR_pitch","WAR_combined","pos_year_stats",
-  "award_data","use_ragg","PLOT_WIDTH","PLOT_HEIGHT","PLOT_DPI"))
+  "award_data","PLOT_WIDTH","PLOT_HEIGHT","PLOT_DPI"))
 
 # Each worker loads the function library once
 parallel::clusterEvalQ(cl, {
   suppressPackageStartupMessages({
     library(ggplot2); library(dplyr); library(tidyr); library(ggrepel); library(ggh4x)
     source("franchise_war_functions.R")
-    if (requireNamespace("ragg", quietly = TRUE)) library(ragg)
   })
 })
 
@@ -99,11 +96,7 @@ render_job <- function(job) {
   p <- generate_franchise_war_plot(war_src, job$tl, start_year=job$era, position_filter=job$pf,
     variable_width=job$vw, pos_year_stats=if(job$vw) pos_year_stats else NULL,
     show_awards=job$sa, award_data=if(job$sa) award_data else NULL, show_postseason=job$sp)
-  if (use_ragg) {
-    ggsave(job$fname, plot=p, width=PLOT_WIDTH, height=PLOT_HEIGHT, dpi=PLOT_DPI, device=ragg::agg_png)
-  } else {
-    ggsave(job$fname, plot=p, width=PLOT_WIDTH, height=PLOT_HEIGHT, dpi=PLOT_DPI)
-  }
+  ggsave(job$fname, plot=p, width=PLOT_WIDTH, height=PLOT_HEIGHT, dpi=PLOT_DPI, device=grDevices::png)
   return(job$fname)
 }
 

--- a/generate_team_breakdowns.R
+++ b/generate_team_breakdowns.R
@@ -35,7 +35,6 @@ OVERLAY_COMBOS <- list(
 message("=== Loading shared data ===")
 pos_year_stats <- compute_position_year_stats(WAR_bat, WAR_pitch)
 award_data <- load_award_data()
-use_ragg <- requireNamespace("ragg", quietly = TRUE)
 
 jobs <- list()
 for (tc in names(TEAMS)) {
@@ -51,18 +50,17 @@ for (tc in names(TEAMS)) {
   }
 }
 
-message(sprintf("\n=== %d images | %d cores | %s ===\n", length(jobs), N_CORES, if(use_ragg)"ragg"else"png"))
+message(sprintf("\n=== %d images | %d cores ===\n", length(jobs), N_CORES))
 
 cl <- parallel::makeCluster(N_CORES)
 
 parallel::clusterExport(cl, c("WAR_bat","WAR_pitch","pos_year_stats","award_data",
-  "use_ragg","PLOT_WIDTH","PLOT_DPI"))
+  "PLOT_WIDTH","PLOT_DPI"))
 
 parallel::clusterEvalQ(cl, {
   suppressPackageStartupMessages({
     library(ggplot2); library(dplyr); library(tidyr); library(ggrepel); library(ggh4x)
     source("franchise_war_functions.R"); source("team_position_breakdown.R")
-    if (requireNamespace("ragg", quietly = TRUE)) library(ragg)
   })
 })
 
@@ -72,11 +70,7 @@ render_job <- function(job) {
     variable_width=job$iz, pos_year_stats=if(job$iz) pos_year_stats else NULL,
     show_awards=job$sa, award_data=if(job$sa) award_data else NULL)
   n_pos <- attr(p, "n_positions"); ph <- 3 * n_pos + 2
-  if (use_ragg) {
-    ggsave(job$fname, plot=p, width=PLOT_WIDTH, height=ph, dpi=PLOT_DPI, device=ragg::agg_png)
-  } else {
-    ggsave(job$fname, plot=p, width=PLOT_WIDTH, height=ph, dpi=PLOT_DPI)
-  }
+  ggsave(job$fname, plot=p, width=PLOT_WIDTH, height=ph, dpi=PLOT_DPI, device=grDevices::png)
   return(job$fname)
 }
 


### PR DESCRIPTION
- Force `grDevices::png` instead of ragg auto-detection (ggplot2 4.x was silently using ragg, causing worse anti-aliasing)
- SEA secondary: chartreuse → legible silver (#8A8D8F)
- COL secondary: washed lavender → darker purple (#9B8BB4)  
- Remove ragg references from generation scripts