### PR TITLE
Revamp z-score methodology: year-specific pools + rolling average

### DIFF
--- a/docs/landing.html
+++ b/docs/landing.html
@@ -146,10 +146,11 @@
         <strong>Z-Score Line Width:</strong> When enabled, line thickness encodes how exceptional a
         player's WAR was <em>relative to their position and era</em>. For each position and year,
         we compute the mean and standard deviation of WAR among qualified players at that position
-        (≥60 games for fielders, ≥30 for DH/RP, ≥15 GS for SP), then smooth with a 3-year
-        centered rolling average to reduce year-to-year noise. The width represents how many
-        standard deviations above the mean a player's season was. Thicker lines = more dominant
-        seasons compared to peers at the same position.
+        (≥60 games for fielders, ≥30 for DH/RP, ≥15 GS for SP). The positional mean is smoothed
+        with a 3-year rolling average to reduce year-to-year noise; the standard deviation is left
+        unsmoothed to preserve actual within-year variance. The width represents how many standard
+        deviations above the mean a player's season was. Thicker lines = more dominant seasons
+        compared to peers at the same position.
       </p>
       <p>
         <strong>Overlay Markers:</strong> Award markers can be toggled on top of the WAR lines.
@@ -222,9 +223,10 @@
       <ul style="margin: 8px 0 0 24px; color: #c0c0d0; line-height: 1.7;">
         <li>Position categorization is somewhat fraught — we assign each player to the position where they logged the most career games.</li>
         <li>The z-score comparison pool uses year-specific position qualification (not career), with
-            minimum games thresholds and a 3-year rolling average for the baseline statistics. This
-            means a player's line thickness reflects how they compared to the actual positional
-            landscape of their era.</li>
+            minimum games thresholds and a 3-year rolling average for the positional mean. Pools with
+            fewer than 8 qualified players use a variance floor. Despite this, z-scores for
+            historically thin positions (DH before universal DH, early relief pitching) should be
+            interpreted with some caution.</li>
         <li>I have not exhaustively checked every graph for errors. If you see something that looks off, please let me know.</li>
       </ul>
     </div>

--- a/docs/landing.html
+++ b/docs/landing.html
@@ -144,11 +144,12 @@
       </p>
       <p>
         <strong>Z-Score Line Width:</strong> When enabled, line thickness encodes how exceptional a
-        player's WAR was <em>relative to their position and era</em>. Specifically, the width
-        represents the number of standard deviations above the league mean WAR for that
-        position-year combination. Thicker lines = more dominant seasons compared to peers at the
-        same position. Of course this correlates strongly with slope, but truly exceptional seasons
-        like Cal Raleigh's 2025 really pop.
+        player's WAR was <em>relative to their position and era</em>. For each position and year,
+        we compute the mean and standard deviation of WAR among qualified players at that position
+        (≥60 games for fielders, ≥30 for DH/RP, ≥15 GS for SP), then smooth with a 3-year
+        centered rolling average to reduce year-to-year noise. The width represents how many
+        standard deviations above the mean a player's season was. Thicker lines = more dominant
+        seasons compared to peers at the same position.
       </p>
       <p>
         <strong>Overlay Markers:</strong> Award markers can be toggled on top of the WAR lines.
@@ -220,7 +221,10 @@
       <p>Known issues and possible quibbles:</p>
       <ul style="margin: 8px 0 0 24px; color: #c0c0d0; line-height: 1.7;">
         <li>Position categorization is somewhat fraught — we assign each player to the position where they logged the most career games.</li>
-        <li>The z-score line width can look inflated in thin position-year combinations (e.g., early relief pitching) due to low sample variance.</li>
+        <li>The z-score comparison pool uses year-specific position qualification (not career), with
+            minimum games thresholds and a 3-year rolling average for the baseline statistics. This
+            means a player's line thickness reflects how they compared to the actual positional
+            landscape of their era.</li>
         <li>I have not exhaustively checked every graph for errors. If you see something that looks off, please let me know.</li>
       </ul>
     </div>

--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -301,7 +301,7 @@ generate_franchise_war_plot <- function(
   top_segments <- NULL
   if (variable_width && !is.null(pos_year_stats)) {
     zscore_pos <- if (!is.null(position_filter) && position_filter %in% 
-                      c("C", "1B", "2B", "SS", "3B", "OF", "SP", "RP")) {
+                      c("C", "1B", "2B", "SS", "3B", "OF", "DH", "SP", "RP")) {
       position_filter
     } else {
       NULL  # Can't z-score mixed positions
@@ -599,25 +599,42 @@ compute_position_year_stats <- function(war_batting, war_pitching) {
     ) %>%
     mutate(sd_WAR = replace_na(sd_WAR, 0))
 
-  # --- Step 6: 3-year centered rolling average ---
-  # Smooths year-to-year noise, especially valuable for thin pools (DH, early RP).
-  # Edge years use available neighbors via coalesce fallback.
+  # --- Step 6: 3-year centered rolling average on mean only ---
+  # Smooths year-to-year noise in the positional mean, especially valuable for
+  # thin pools (DH, early RP). SD is left unsmoothed because it should reflect
+  # actual within-year dispersion (e.g., strike-shortened seasons genuinely have
+  # different variance). Uses time-aware windowing: only averages adjacent
+  # calendar years (not just adjacent rows), and uses proper partial windows at
+  # boundaries instead of double-counting edge values.
+  # For pools with fewer than 8 qualified players, SD is replaced with the floor
+  # since the sample variance from tiny pools is unreliable.
+  MIN_POOL_SIZE <- 8
   pos_year_stats <- pos_year_raw %>%
     group_by(position) %>%
     arrange(yearID) %>%
     mutate(
-      mean_WAR = (lag(mean_WAR, default = first(mean_WAR)) +
-                  mean_WAR +
-                  lead(mean_WAR, default = last(mean_WAR))) / 3,
-      sd_WAR   = (lag(sd_WAR, default = first(sd_WAR)) +
-                  sd_WAR +
-                  lead(sd_WAR, default = last(sd_WAR))) / 3
+      prev_year = lag(yearID),
+      next_year = lead(yearID),
+      prev_mean = lag(mean_WAR),
+      next_mean = lead(mean_WAR),
+      # Only include neighbors if they are exactly 1 year away
+      has_prev = !is.na(prev_year) & (yearID - prev_year == 1),
+      has_next = !is.na(next_year) & (next_year - yearID == 1),
+      mean_WAR = case_when(
+        has_prev & has_next ~ (prev_mean + mean_WAR + next_mean) / 3,
+        has_prev            ~ (prev_mean + mean_WAR) / 2,
+        has_next            ~ (mean_WAR + next_mean) / 2,
+        TRUE                ~ mean_WAR
+      ),
+      # Use SD floor for tiny pools where sample variance is unreliable
+      sd_WAR = if_else(n_players < MIN_POOL_SIZE, NA_real_, sd_WAR)
     ) %>%
+    select(-prev_year, -next_year, -prev_mean, -next_mean, -has_prev, -has_next) %>%
     ungroup() %>%
-    mutate(sd_WAR = pmax(sd_WAR, 0.5)) %>%
+    mutate(sd_WAR = pmax(coalesce(sd_WAR, 0), 0.5)) %>%
     rename(year_ID = yearID)
 
-  message(sprintf("  %d position-years computed (3-yr rolling, qualified pools)",
+  message(sprintf("  %d position-years computed (3-yr rolling mean, qualified pools)",
                   nrow(pos_year_stats)))
   pos_year_stats
 }

--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -521,60 +521,104 @@ load_award_data <- function() {
 
 compute_position_year_stats <- function(war_batting, war_pitching) {
   message("Computing league-wide position-year WAR distributions...")
-  
-  # League-wide pitcher classification
-  league_pitcher_type <- Lahman::Pitching %>%
-    group_by(playerID) %>%
-    summarise(
-      total_G = sum(G, na.rm = TRUE),
-      total_GS = sum(GS, na.rm = TRUE),
-      .groups = "drop"
+
+  # --- Step 1: Year-specific position assignment from Appearances ---
+  # Classify each player-year by the position where they played the most games
+  # that season, rather than career-wide primary position. This ensures the
+  # comparison pool reflects the actual positional landscape each year.
+  pos_games <- Lahman::Appearances %>%
+    transmute(
+      playerID, yearID,
+      C  = G_c,
+      `1B` = G_1b,
+      `2B` = G_2b,
+      SS = G_ss,
+      `3B` = G_3b,
+      OF = G_lf + G_cf + G_rf,
+      DH = G_dh,
+      P  = G_p
     ) %>%
-    mutate(pitcher_role = if_else(total_GS > total_G * 0.5, "SP", "RP")) %>%
-    select(playerID, pitcher_role)
-  
-  # League-wide DH detection
-  league_dh_players <- Lahman::Appearances %>%
-    group_by(playerID) %>%
-    summarise(
-      dh_games = sum(G_dh, na.rm = TRUE),
-      field_games = sum(G_defense, na.rm = TRUE),
-      .groups = "drop"
-    ) %>%
-    filter(dh_games > field_games * 0.5) %>%
-    mutate(is_primary_dh = TRUE) %>%
-    select(playerID, is_primary_dh)
-  
-  common_cols <- c("year_ID", "player_ID", "name_common", "team_ID", "WAR", "primary_pos")
-  league_war <- bind_rows(
-    war_batting %>% select(all_of(common_cols)),
-    war_pitching %>% select(all_of(common_cols))
-  ) %>%
-    filter(!is.na(WAR), !is.na(primary_pos)) %>%
-    left_join(league_dh_players, by = c("player_ID" = "playerID")) %>%
-    left_join(league_pitcher_type, by = c("player_ID" = "playerID")) %>%
+    pivot_longer(cols = c(C, `1B`, `2B`, SS, `3B`, OF, DH, P),
+                 names_to = "position", values_to = "games") %>%
+    filter(games > 0) %>%
+    group_by(playerID, yearID) %>%
+    slice_max(order_by = games, n = 1, with_ties = FALSE) %>%
+    ungroup()
+
+  # --- Step 2: SP/RP split for pitchers (year-specific) ---
+  pitcher_yearly <- Lahman::Pitching %>%
+    group_by(playerID, yearID) %>%
+    summarise(G = sum(G, na.rm = TRUE), GS = sum(GS, na.rm = TRUE),
+              .groups = "drop") %>%
+    mutate(pitcher_role = if_else(GS > G * 0.5, "SP", "RP"))
+
+  pos_games <- pos_games %>%
+    left_join(pitcher_yearly %>% select(playerID, yearID, pitcher_role, GS),
+              by = c("playerID", "yearID")) %>%
     mutate(position = case_when(
-      !is.na(is_primary_dh) ~ "DH",
-      primary_pos %in% c("LF", "CF", "RF") ~ "OF",
-      primary_pos == "P" & pitcher_role == "RP" ~ "RP",
-      primary_pos == "P" ~ "SP",
-      TRUE ~ primary_pos
-    )) %>%
-    filter(position %in% c("C", "1B", "2B", "SS", "3B", "OF", "DH", "SP", "RP")) %>%
-    group_by(player_ID, position, year_ID) %>%
+      position == "P" & pitcher_role == "RP" ~ "RP",
+      position == "P" ~ "SP",
+      TRUE ~ position
+    ))
+
+  # --- Step 3: Apply minimum-games thresholds ---
+  # Field positions: 60 games (~37% of season) — captures regulars
+  # DH: 30 games — lower bar since even full-time DHs get rested/platooned
+  # SP: 15 GS — roughly one start every 10 days
+  # RP: 30 games
+  qualified <- pos_games %>%
+    filter(
+      (position %in% c("C", "1B", "2B", "SS", "3B", "OF") & games >= 60) |
+      (position == "DH" & games >= 30) |
+      (position == "SP" & !is.na(GS) & GS >= 15) |
+      (position == "RP" & games >= 30)
+    )
+
+  # --- Step 4: Join WAR values ---
+  all_war <- bind_rows(
+    war_batting  %>% select(year_ID, player_ID, WAR),
+    war_pitching %>% select(year_ID, player_ID, WAR)
+  ) %>%
+    mutate(WAR = as.numeric(WAR)) %>%
+    filter(!is.na(WAR)) %>%
+    group_by(player_ID, year_ID) %>%
     summarise(WAR = sum(WAR, na.rm = TRUE), .groups = "drop")
-  
-  pos_year_stats <- league_war %>%
-    group_by(position, year_ID) %>%
+
+  league_war <- qualified %>%
+    inner_join(all_war,
+               by = c("playerID" = "player_ID", "yearID" = "year_ID"))
+
+  # --- Step 5: Compute raw position-year stats ---
+  pos_year_raw <- league_war %>%
+    group_by(position, yearID) %>%
     summarise(
       mean_WAR = mean(WAR, na.rm = TRUE),
-      sd_WAR = sd(WAR, na.rm = TRUE),
+      sd_WAR   = sd(WAR, na.rm = TRUE),
       n_players = n(),
       .groups = "drop"
     ) %>%
-    mutate(sd_WAR = pmax(sd_WAR, 0.5))
-  
-  message(sprintf("  %d position-years computed", nrow(pos_year_stats)))
+    mutate(sd_WAR = replace_na(sd_WAR, 0))
+
+  # --- Step 6: 3-year centered rolling average ---
+  # Smooths year-to-year noise, especially valuable for thin pools (DH, early RP).
+  # Edge years use available neighbors via coalesce fallback.
+  pos_year_stats <- pos_year_raw %>%
+    group_by(position) %>%
+    arrange(yearID) %>%
+    mutate(
+      mean_WAR = (lag(mean_WAR, default = first(mean_WAR)) +
+                  mean_WAR +
+                  lead(mean_WAR, default = last(mean_WAR))) / 3,
+      sd_WAR   = (lag(sd_WAR, default = first(sd_WAR)) +
+                  sd_WAR +
+                  lead(sd_WAR, default = last(sd_WAR))) / 3
+    ) %>%
+    ungroup() %>%
+    mutate(sd_WAR = pmax(sd_WAR, 0.5)) %>%
+    rename(year_ID = yearID)
+
+  message(sprintf("  %d position-years computed (3-yr rolling, qualified pools)",
+                  nrow(pos_year_stats)))
   pos_year_stats
 }
 


### PR DESCRIPTION
## Summary

Overhauls the z-score comparison pool so line thickness better reflects how exceptional a player's season was relative to the actual positional landscape of their era.

### Problem
The old approach used **career-primary position** to build the comparison pool. For DHs, this meant Edgar Martínez was only compared against other career DHs (Ortiz, Thomas, Baines) — a self-selected group of good hitters. His peak 7 WAR seasons only registered ~1.5-2.0σ.

### Solution
`compute_position_year_stats()` now:
- **Year-specific position assignment** from `Lahman::Appearances` (most games at position *that season*)
- **Minimum games thresholds**: 60 for fielders, 30 for DH/RP, 15 GS for SP
- **3-year centered rolling average** smooths mean/SD, reducing noise for thin pools
- SD floor remains at 0.5

Also adds DH to the allowed z-score position list in the franchise grid view.

### Impact

| Player | Season | WAR | Old z-score | New z-score |
|--------|--------|-----|-------------|-------------|
| Edgar Martínez | 1995 | 7.05 | ~1.5-2.0σ | **3.0σ** |
| Edgar Martínez | 1992 | 6.52 | ~1.5σ | **2.6σ** |
| A-Rod (SS sanity check) | 2000 | 10.4 | ~3.0σ | **3.5σ** |

### Files Changed
- `franchise_war_functions.R` — rewritten `compute_position_year_stats()`, added DH to z-score positions, added `data.table` import
- `docs/landing.html` — updated z-score description and methodology caveats

### ⚠️ Note
PNGs will need to be regenerated after merge to reflect the new z-score widths.