### PR TITLE
Improve pan/zoom discoverability in image viewers

### DIFF
--- a/docs/team_breakdown.html
+++ b/docs/team_breakdown.html
@@ -145,8 +145,8 @@
       color: #e0e0e0;
     }
     .zoom-hint {
-      font-size: 12px;
-      color: #666;
+      font-size: 13px;
+      color: #aaa;
     }
     .overlay-legend {
       background: #16213e;
@@ -173,8 +173,33 @@
       border: 1px solid #1f3460;
       border-radius: 4px;
       background: #0d1321;
+      position: relative;
     }
     .image-wrapper:active { cursor: grabbing; }
+    .pan-indicator {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 60px;
+      background: linear-gradient(transparent, rgba(13, 19, 33, 0.9));
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      padding-bottom: 10px;
+      pointer-events: none;
+      z-index: 10;
+      transition: opacity 0.6s ease;
+    }
+    .pan-indicator span {
+      color: #7ec8e3;
+      font-size: 13px;
+      animation: bounce 1.5s infinite;
+    }
+    @keyframes bounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
     .panzoom-container img {
       width: 100%;
       display: block;
@@ -305,6 +330,7 @@
       <div class="panzoom-container" id="panzoom-container">
         <img id="plot-image" src="team_breakdowns/SEA_linear_const.png" alt="Team Breakdown Plot" style="width:100%; display:block;">
       </div>
+      <div class="pan-indicator" id="pan-indicator"><span>↓ Drag to see more positions ↓</span></div>
     </div>
   </div>
 
@@ -346,6 +372,15 @@
     });
     imageWrapper.addEventListener('wheel', panzoom.zoomWithWheel);
     resetBtn.addEventListener('click', () => panzoom.reset());
+
+    // Dismiss the "drag to see more" indicator on first interaction
+    const panIndicator = document.getElementById('pan-indicator');
+    function dismissIndicator() {
+      if (panIndicator) panIndicator.style.opacity = '0';
+    }
+    imageWrapper.addEventListener('mousedown', dismissIndicator, { once: true });
+    imageWrapper.addEventListener('wheel', dismissIndicator, { once: true });
+    imageWrapper.addEventListener('touchstart', dismissIndicator, { once: true });
 
     function resetZoom() {
       panzoom.reset({ animate: false });

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -152,8 +152,8 @@
       color: #e0e0e0;
     }
     .zoom-hint {
-      font-size: 12px;
-      color: #666;
+      font-size: 13px;
+      color: #aaa;
     }
     .overlay-legend {
       background: #16213e;
@@ -180,8 +180,33 @@
       border: 1px solid #1f3460;
       border-radius: 4px;
       background: #0d1321;
+      position: relative;
     }
     .image-wrapper:active { cursor: grabbing; }
+    .pan-indicator {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 60px;
+      background: linear-gradient(transparent, rgba(13, 19, 33, 0.9));
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      padding-bottom: 10px;
+      pointer-events: none;
+      z-index: 10;
+      transition: opacity 0.6s ease;
+    }
+    .pan-indicator span {
+      color: #7ec8e3;
+      font-size: 13px;
+      animation: bounce 1.5s infinite;
+    }
+    @keyframes bounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
     .panzoom-container img {
       width: 100%;
       display: block;
@@ -307,6 +332,7 @@
       <div class="panzoom-container" id="panzoom-container">
         <img id="plot-image" src="plots/all_1901.png" alt="WAR Plot" style="width:100%; display:block;">
       </div>
+      <div class="pan-indicator" id="pan-indicator"><span>↓ Drag to see more teams ↓</span></div>
     </div>
     <div class="era-info" id="era-info"></div>
     <div class="data-link">
@@ -364,6 +390,15 @@
     });
     imageWrapper.addEventListener('wheel', panzoom.zoomWithWheel);
     resetBtn.addEventListener('click', () => panzoom.reset());
+
+    // Dismiss the "drag to see more" indicator on first interaction
+    const panIndicator = document.getElementById('pan-indicator');
+    function dismissIndicator() {
+      if (panIndicator) panIndicator.style.opacity = '0';
+    }
+    imageWrapper.addEventListener('mousedown', dismissIndicator, { once: true });
+    imageWrapper.addEventListener('wheel', dismissIndicator, { once: true });
+    imageWrapper.addEventListener('touchstart', dismissIndicator, { once: true });
 
     function resetZoom() {
       panzoom.reset({ animate: false });


### PR DESCRIPTION
## Problem
Users don't realize the plot images extend beyond the visible viewport and that they need to click-drag to pan down.

## Changes
- **Bouncing indicator**: Added a "↓ Drag to see more teams/positions ↓" label at the bottom of the image area with a subtle bounce animation
- **Gradient fade**: Bottom edge fades from transparent to the background color, visually hinting that content continues below
- **Auto-dismiss**: The indicator fades out on the first mouse, wheel, or touch interaction (uses CSS opacity transition)
- **Better hint text**: Bumped the zoom/pan hint from `#666` → `#aaa` (much more visible on the dark background) and 12px → 13px

Applied to both `war_explorer.html` and `team_breakdown.html`.

## Technical notes
- `pointer-events: none` on the indicator so it doesn't interfere with Panzoom drag events
- `{ once: true }` event listeners for clean auto-dismissal
- Zero new dependencies