### PR TITLE
Style grid facet labels: team colors, larger text, panel borders

### DIFF
--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -159,6 +159,12 @@ divisions <- tribble(
   "WSN", "NL", "East", 6
 )
 
+# Pre-build per-team colored strip text elements for facet labels
+.strip_franchise_order <- divisions$franchise[order(divisions$div_order, divisions$franchise)]
+.strip_text_elems <- lapply(primary_colors[.strip_franchise_order], function(col) {
+  element_text(face = "bold", size = 14, colour = col)
+})
+
 # =============================================================================
 # DATA LOADING FUNCTIONS
 # =============================================================================
@@ -427,7 +433,8 @@ generate_franchise_war_plot <- function(
   p <- p +
     scale_color_manual(values = primary_colors, guide = "none") +
     scale_x_continuous(breaks = x_breaks) +
-    ggh4x::facet_wrap2(~ reorder(franchise, div_order), ncol = 5, axes = "x") +
+    ggh4x::facet_wrap2(~ reorder(franchise, div_order), ncol = 5, axes = "x",
+      strip = ggh4x::strip_themed(text_x = .strip_text_elems)) +
     coord_cartesian(xlim = c(start_year, 2026), ylim = c(0, ceiling(max(top_plot_data$cumWAR_franchise, na.rm = TRUE) * 1.1 / 5) * 5)) +
     theme_minimal() +
     theme(
@@ -435,9 +442,9 @@ generate_franchise_war_plot <- function(
       legend.justification = "left",
       legend.box = "horizontal",
       legend.box.just = "left",
-      panel.spacing.x = unit(1.2, "lines"),
-      panel.spacing.y = unit(0.8, "lines"),
-      strip.text = element_text(face = "bold", size = 9),
+      panel.spacing.x = unit(1.5, "lines"),
+      panel.spacing.y = unit(1.2, "lines"),
+      panel.border = element_rect(colour = "#444444", fill = NA, linewidth = 0.5),
       axis.text = element_text(size = 6),
       axis.text.x = element_text(angle = 0),
       panel.grid.minor = element_blank()

--- a/team_position_breakdown.R
+++ b/team_position_breakdown.R
@@ -346,7 +346,7 @@ generate_team_position_plot <- function(
       legend.margin = margin(0, 0, 5, 0),
       legend.spacing.x = unit(0.8, "cm"),
       panel.spacing = unit(0.8, "lines"),
-      strip.text = element_text(face = "bold", size = 11),
+      strip.text = element_text(face = "bold", size = 13),
       axis.text = element_text(size = 8),
       panel.grid.major = element_line(color = "gray92", linewidth = 0.3),
       panel.grid.minor = element_blank(),


### PR DESCRIPTION
## Changes to `franchise_war_functions.R`

Based on feedback that team names in the 30-team grid run together.

### Label styling
- **Size**: 9pt → 14pt bold
- **Color**: Each team's label now uses its primary team color (via `ggh4x::strip_themed`)
- Pre-built at module level (`.strip_text_elems`) so it's computed once, not per-plot

### Panel delineation
- Added subtle gray panel borders (`#444`, 0.5pt)
- Increased panel spacing: x 1.2→1.5 lines, y 0.8→1.2 lines

### Note
All ~900 PNGs need to be regenerated after merging for changes to appear on the site.