### PR TITLE
Link grid teams to breakdown view on click

### DIFF
--- a/docs/team_breakdown.html
+++ b/docs/team_breakdown.html
@@ -429,6 +429,14 @@
       this.alt = 'Plot not yet generated. Run the R scripts first.';
     });
 
+    // --- URL parameter handling ---
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('team') && teamNames[urlParams.get('team')]) {
+      teamSelect.value = urlParams.get('team');
+    }
+    if (urlParams.get('awards') === '1') awardsCheck.checked = true;
+    if (urlParams.get('postseason') === '1') postseasonCheck.checked = true;
+
     updatePlot();
   </script>
 </body>

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -475,12 +475,19 @@
       NYM:'New York Mets', PHI:'Philadelphia Phillies', WSN:'Washington Nationals'
     };
     // Grid bounding box as fractions of image (measured from rendered plots)
-    const GRID = { left: 0.012, right: 0.997, top: 0.033, bottom: 0.999, cols: 5, rows: 6 };
+    // Awards/postseason legends push panels down, so top shifts
+    const GRID_BASE    = { left: 0.0155, right: 1.0, top: 0.022, bottom: 0.991, cols: 5, rows: 6 };
+    const GRID_OVERLAY = { left: 0.0155, right: 1.0, top: 0.0446, bottom: 0.991, cols: 5, rows: 6 };
+
+    function getGrid() {
+      return (awardsCheck.checked || postseasonCheck.checked) ? GRID_OVERLAY : GRID_BASE;
+    }
 
     const teamTooltip = document.getElementById('team-tooltip');
     let mouseDownPos = null;
 
     function getGridTeam(e) {
+      const GRID = getGrid();
       const scale = panzoom.getScale();
       const pan = panzoom.getPan();
       // Convert page coords to image-fraction coords

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -211,6 +211,20 @@
       width: 100%;
       display: block;
     }
+    .team-tooltip {
+      position: absolute;
+      background: rgba(22, 33, 62, 0.92);
+      color: #7ec8e3;
+      padding: 5px 10px;
+      border-radius: 4px;
+      font-size: 13px;
+      font-weight: 600;
+      pointer-events: none;
+      z-index: 20;
+      white-space: nowrap;
+      display: none;
+      border: 1px solid #1f3460;
+    }
     .era-info {
       font-size: 13px;
       color: #8888aa;
@@ -317,12 +331,13 @@
   <div class="plot-container">
     <div class="plot-header">
       <div class="plot-title" id="plot-title">Cumulative WAR by Franchise — All Players (1901-Present)</div>
-      <div class="zoom-hint">🔍 Scroll to pan · ⌘/Ctrl+scroll to zoom · Drag to pan</div>
+      <div class="zoom-hint">🔍 Scroll to pan · ⌘/Ctrl+scroll to zoom · Click a team to see its breakdown</div>
     </div>
     <div class="image-wrapper" id="image-wrapper">
       <div class="panzoom-container" id="panzoom-container">
         <img id="plot-image" src="plots/all_1901.png" alt="WAR Plot" style="width:100%; display:block;">
       </div>
+      <div class="team-tooltip" id="team-tooltip"></div>
       <div class="pan-indicator" id="pan-indicator"><span>↓ Drag to see more teams ↓</span></div>
     </div>
     <div class="era-info" id="era-info"></div>
@@ -435,6 +450,93 @@
     // Handle image load errors
     plotImage.addEventListener('error', function() {
       this.alt = 'Plot not yet generated. Run generate_all_plots.R first.';
+    });
+
+    // --- Click-to-navigate: grid image → team breakdown ---
+    // 5 cols × 6 rows, teams ordered by division (alphabetical within)
+    const GRID_TEAMS = [
+      ['HOU','LAA','OAK','SEA','TEX'],  // AL West
+      ['CHW','CLE','DET','KCR','MIN'],  // AL Central
+      ['BAL','BOS','NYY','TBR','TOR'],  // AL East
+      ['ARI','COL','LAD','SDP','SFG'],  // NL West
+      ['CHC','CIN','MIL','PIT','STL'],  // NL Central
+      ['ATL','MIA','NYM','PHI','WSN'],  // NL East
+    ];
+    const GRID_NAMES = {
+      HOU:'Houston Astros', LAA:'Los Angeles Angels', OAK:'Oakland Athletics',
+      SEA:'Seattle Mariners', TEX:'Texas Rangers', CHW:'Chicago White Sox',
+      CLE:'Cleveland Guardians', DET:'Detroit Tigers', KCR:'Kansas City Royals',
+      MIN:'Minnesota Twins', BAL:'Baltimore Orioles', BOS:'Boston Red Sox',
+      NYY:'New York Yankees', TBR:'Tampa Bay Rays', TOR:'Toronto Blue Jays',
+      ARI:'Arizona Diamondbacks', COL:'Colorado Rockies', LAD:'Los Angeles Dodgers',
+      SDP:'San Diego Padres', SFG:'San Francisco Giants', CHC:'Chicago Cubs',
+      CIN:'Cincinnati Reds', MIL:'Milwaukee Brewers', PIT:'Pittsburgh Pirates',
+      STL:'St. Louis Cardinals', ATL:'Atlanta Braves', MIA:'Miami Marlins',
+      NYM:'New York Mets', PHI:'Philadelphia Phillies', WSN:'Washington Nationals'
+    };
+    // Grid bounding box as fractions of image (measured from rendered plots)
+    const GRID = { left: 0.012, right: 0.997, top: 0.033, bottom: 0.999, cols: 5, rows: 6 };
+
+    const teamTooltip = document.getElementById('team-tooltip');
+    let mouseDownPos = null;
+
+    function getGridTeam(e) {
+      const rect = plotImage.getBoundingClientRect();
+      const scale = panzoom.getScale();
+      const pan = panzoom.getPan();
+      // Convert page coords to image-fraction coords
+      const wrapperRect = imageWrapper.getBoundingClientRect();
+      const imgDisplayW = plotImage.offsetWidth * scale;
+      const imgDisplayH = plotImage.offsetHeight * scale;
+      const imgLeft = wrapperRect.left + pan.x;
+      const imgTop = wrapperRect.top + pan.y;
+      const fx = (e.clientX - imgLeft) / imgDisplayW;
+      const fy = (e.clientY - imgTop) / imgDisplayH;
+      // Map to grid cell
+      if (fx < GRID.left || fx > GRID.right || fy < GRID.top || fy > GRID.bottom) return null;
+      const col = Math.floor((fx - GRID.left) / (GRID.right - GRID.left) * GRID.cols);
+      const row = Math.floor((fy - GRID.top) / (GRID.bottom - GRID.top) * GRID.rows);
+      if (row < 0 || row >= GRID.rows || col < 0 || col >= GRID.cols) return null;
+      return GRID_TEAMS[row][col];
+    }
+
+    imageWrapper.addEventListener('mousedown', (e) => {
+      mouseDownPos = { x: e.clientX, y: e.clientY };
+    });
+
+    imageWrapper.addEventListener('mouseup', (e) => {
+      if (!mouseDownPos) return;
+      const dx = e.clientX - mouseDownPos.x;
+      const dy = e.clientY - mouseDownPos.y;
+      mouseDownPos = null;
+      // Only navigate if this was a click, not a drag
+      if (Math.sqrt(dx*dx + dy*dy) > 5) return;
+      const team = getGridTeam(e);
+      if (!team) return;
+      const params = new URLSearchParams();
+      params.set('team', team);
+      if (awardsCheck.checked) params.set('awards', '1');
+      if (postseasonCheck.checked) params.set('postseason', '1');
+      window.location.href = `team_breakdown.html?${params.toString()}`;
+    });
+
+    imageWrapper.addEventListener('mousemove', (e) => {
+      const team = getGridTeam(e);
+      if (team) {
+        teamTooltip.textContent = GRID_NAMES[team];
+        teamTooltip.style.display = 'block';
+        const wrapperRect = imageWrapper.getBoundingClientRect();
+        teamTooltip.style.left = (e.clientX - wrapperRect.left + 12) + 'px';
+        teamTooltip.style.top = (e.clientY - wrapperRect.top - 30) + 'px';
+        imageWrapper.style.cursor = 'pointer';
+      } else {
+        teamTooltip.style.display = 'none';
+        imageWrapper.style.cursor = 'grab';
+      }
+    });
+
+    imageWrapper.addEventListener('mouseleave', () => {
+      teamTooltip.style.display = 'none';
     });
 
     // Initialize

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -481,7 +481,6 @@
     let mouseDownPos = null;
 
     function getGridTeam(e) {
-      const rect = plotImage.getBoundingClientRect();
       const scale = panzoom.getScale();
       const pan = panzoom.getPan();
       // Convert page coords to image-fraction coords
@@ -526,8 +525,14 @@
         teamTooltip.textContent = GRID_NAMES[team];
         teamTooltip.style.display = 'block';
         const wrapperRect = imageWrapper.getBoundingClientRect();
-        teamTooltip.style.left = (e.clientX - wrapperRect.left + 12) + 'px';
-        teamTooltip.style.top = (e.clientY - wrapperRect.top - 30) + 'px';
+        let tipLeft = e.clientX - wrapperRect.left + 12;
+        let tipTop = e.clientY - wrapperRect.top - 30;
+        // Keep tooltip within the wrapper bounds
+        const tipW = teamTooltip.offsetWidth;
+        if (tipLeft + tipW > imageWrapper.clientWidth) tipLeft = e.clientX - wrapperRect.left - tipW - 8;
+        if (tipTop < 0) tipTop = e.clientY - wrapperRect.top + 16;
+        teamTooltip.style.left = tipLeft + 'px';
+        teamTooltip.style.top = tipTop + 'px';
         imageWrapper.style.cursor = 'pointer';
       } else {
         teamTooltip.style.display = 'none';


### PR DESCRIPTION
## Summary

Click any team in the 30-team grid explorer to navigate directly to that team's position breakdown.

### Changes
- **war_explorer.html**: Added click detection over the 5×6 facet grid. Hovering shows a tooltip with the team name; clicking navigates to `team_breakdown.html?team=XXX`. Awards/postseason checkbox state is carried over via URL params.
- **team_breakdown.html**: Reads `?team=XXX&awards=1&postseason=1` URL parameters on load to auto-select the team and toggle overlay checkboxes.

### Implementation
- Grid mapping uses measured panel positions from the rendered ggplot facet layout (5 cols × 6 rows, ordered by division)
- Click vs. drag disambiguation (5px movement threshold) so panning still works normally
- Coordinate transforms account for Panzoom zoom/pan state

### No regeneration needed
Pure HTML/JS changes — no R code or PNGs affected.