### PR TITLE
Shareable URLs for both viewers

### DIFF
--- a/docs/team_breakdown.html
+++ b/docs/team_breakdown.html
@@ -319,6 +319,7 @@
     </div>
 
     <button class="reset-btn" id="reset-zoom">Reset Zoom</button>
+    <button class="reset-btn" id="share-link" title="Copy shareable link">📋 Copy Link</button>
   </div>
 
   <div class="plot-container">
@@ -393,6 +394,14 @@
       panzoom.reset({ animate: false });
     }
 
+    // --- URL state: read params on load ---
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('team') && teamNames[urlParams.get('team')]) teamSelect.value = urlParams.get('team');
+    if (urlParams.has('scale')) scaleSelect.value = urlParams.get('scale');
+    if (urlParams.has('width')) widthSelect.value = urlParams.get('width');
+    if (urlParams.has('awards')) awardsCheck.checked = urlParams.get('awards') === '1';
+    if (urlParams.has('postseason')) postseasonCheck.checked = urlParams.get('postseason') === '1';
+
     function updatePlot() {
       const team = teamSelect.value;
       const scale = scaleSelect.value;
@@ -417,6 +426,16 @@
       const scaleLabel = scale === 'linear' ? 'Linear' : 'Log';
       const widthLabel = width === 'const' ? 'Constant Width' : 'Z-Score Width';
       plotTitle.textContent = `${name} — Position Breakdown (${scaleLabel}, ${widthLabel})`;
+
+      // Update URL without adding history entry
+      const params = new URLSearchParams();
+      params.set('team', team);
+      if (scale !== 'linear') params.set('scale', scale);
+      if (width !== 'const') params.set('width', width);
+      if (showAwards) params.set('awards', '1');
+      if (showPostseason) params.set('postseason', '1');
+      const qs = params.toString();
+      history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname);
     }
 
     teamSelect.addEventListener('change', updatePlot);
@@ -425,17 +444,17 @@
     awardsCheck.addEventListener('change', updatePlot);
     postseasonCheck.addEventListener('change', updatePlot);
 
+    document.getElementById('share-link').addEventListener('click', () => {
+      navigator.clipboard.writeText(window.location.href).then(() => {
+        const btn = document.getElementById('share-link');
+        btn.textContent = '✓ Copied!';
+        setTimeout(() => { btn.textContent = '📋 Copy Link'; }, 1500);
+      });
+    });
+
     plotImage.addEventListener('error', function() {
       this.alt = 'Plot not yet generated. Run the R scripts first.';
     });
-
-    // --- URL parameter handling ---
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has('team') && teamNames[urlParams.get('team')]) {
-      teamSelect.value = urlParams.get('team');
-    }
-    if (urlParams.get('awards') === '1') awardsCheck.checked = true;
-    if (urlParams.get('postseason') === '1') postseasonCheck.checked = true;
 
     updatePlot();
   </script>

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -326,6 +326,7 @@
     </div>
     
     <button class="reset-btn" id="reset-zoom">Reset Zoom</button>
+    <button class="reset-btn" id="share-link" title="Copy shareable link">📋 Copy Link</button>
   </div>
 
   <div class="plot-container">
@@ -413,6 +414,13 @@
       panzoom.reset({ animate: false });
     }
 
+    // --- URL state: read params on load ---
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('pos')) positionSelect.value = urlParams.get('pos');
+    if (urlParams.has('era')) eraSelect.value = urlParams.get('era');
+    if (urlParams.has('awards')) awardsCheck.checked = urlParams.get('awards') === '1';
+    if (urlParams.has('postseason')) postseasonCheck.checked = urlParams.get('postseason') === '1';
+
     function updatePlot() {
       const position = positionSelect.value;
       const era = eraSelect.value;
@@ -440,12 +448,29 @@
       
       // Update era info
       eraInfoDiv.textContent = eraInfo[era];
+
+      // Update URL without adding history entry
+      const params = new URLSearchParams();
+      if (position !== 'all') params.set('pos', position);
+      if (era !== '1901') params.set('era', era);
+      if (showAwards) params.set('awards', '1');
+      if (showPostseason) params.set('postseason', '1');
+      const qs = params.toString();
+      history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname);
     }
 
     positionSelect.addEventListener('change', updatePlot);
     eraSelect.addEventListener('change', updatePlot);
     awardsCheck.addEventListener('change', updatePlot);
     postseasonCheck.addEventListener('change', updatePlot);
+
+    document.getElementById('share-link').addEventListener('click', () => {
+      navigator.clipboard.writeText(window.location.href).then(() => {
+        const btn = document.getElementById('share-link');
+        btn.textContent = '✓ Copied!';
+        setTimeout(() => { btn.textContent = '📋 Copy Link'; }, 1500);
+      });
+    });
     
     // Handle image load errors
     plotImage.addEventListener('error', function() {


### PR DESCRIPTION
## Summary
View state is now encoded in URL query params so any configuration can be shared with a link.

### How it works
- Controls sync to URL via `history.replaceState` on every change (no history spam)
- On page load, URL params restore the exact view
- Default values are omitted for clean URLs

### URL params
| Page | Params |
|------|--------|
| Explorer | `pos`, `era`, `awards`, `postseason` |
| Breakdown | `team`, `scale`, `width`, `awards`, `postseason` |

### Examples
- `war_explorer.html?pos=ss&era=1961&awards=1` → Shortstops since 1961 with award markers
- `team_breakdown.html?team=SEA&width=zscore&postseason=1` → Mariners z-score with postseason

### Copy Link button
Added a 📋 Copy Link button next to Reset Zoom on both pages. Shows ✓ Copied! confirmation for 1.5s.

### Compatibility with PR #20
PR #20 adds `?team=` param reading to team_breakdown for click-to-navigate. This PR uses the same param name, so they're compatible — whichever merges second just needs a trivial dedup of the URL reading block.