### PR TITLE
Site polish: OG meta tags, mobile warning, nav width fix

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -3,7 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MLB Franchise WAR Visualizations</title>
+  <title>About — MLB Franchise WAR Visualizations</title>
+  <meta property="og:title" content="About — MLB Franchise WAR Visualizations">
+  <meta property="og:description" content="Methodology, data sources, and technical details behind the MLB Franchise WAR visualizations.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://keownb.github.io/R-Baseball-Experiments/about.html">
+  <meta property="og:image" content="https://keownb.github.io/R-Baseball-Experiments/plots/all_1901.png">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚾</text></svg>">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MLB Franchise WAR Visualizations</title>
+  <meta property="og:title" content="MLB Franchise WAR Visualizations">
+  <meta property="og:description" content="Interactive cumulative WAR trajectories for every MLB franchise, 1901–present. Explore careers by position, era, and team.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://keownb.github.io/R-Baseball-Experiments/">
+  <meta property="og:image" content="https://keownb.github.io/R-Baseball-Experiments/plots/all_1901.png">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚾</text></svg>">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/docs/team_breakdown.html
+++ b/docs/team_breakdown.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Team Position Breakdown — MLB WAR</title>
+  <meta property="og:title" content="Team Position Breakdown — MLB WAR">
+  <meta property="og:description" content="Per-team position-by-position WAR breakdown. Compare careers across all 9 positions with z-score analysis.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://keownb.github.io/R-Baseball-Experiments/team_breakdown.html">
+  <meta property="og:image" content="https://keownb.github.io/R-Baseball-Experiments/plots/all_1901.png">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚾</text></svg>">
   <script src="https://unpkg.com/@panzoom/panzoom@4.5.1/dist/panzoom.min.js"></script>
   <style>
@@ -218,12 +224,23 @@
       text-decoration: none;
     }
     footer a:hover { text-decoration: underline; }
+    .mobile-warning {
+      display: none;
+      background: #f5c518;
+      color: #1a1a2e;
+      text-align: center;
+      padding: 10px 20px;
+      font-weight: 700;
+      font-size: 14px;
+    }
+    @media (max-width: 720px) {
+      .mobile-warning { display: block; }
+    }
   </style>
 </head>
 <body>
-  <div class="nav" style="max-width:1600px;">
-    <div><a href="index.html">← Home</a> · <a href="about.html">About</a></div>
-    <div><a href="war_explorer.html">← Grid Explorer</a></div>
+  <div class="mobile-warning">⚠️ Built for large displays. Best viewed on desktop.</div>
+  <div class="nav" style="max-width:2400px;">
   </div>
 
   <h1>⚾ Team Position Breakdown</h1>

--- a/docs/war_explorer.html
+++ b/docs/war_explorer.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MLB Franchise WAR Explorer</title>
+  <meta property="og:title" content="MLB Franchise WAR Explorer">
+  <meta property="og:description" content="30-team grid of cumulative WAR by franchise. Filter by position, era, awards, and postseason appearances.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://keownb.github.io/R-Baseball-Experiments/war_explorer.html">
+  <meta property="og:image" content="https://keownb.github.io/R-Baseball-Experiments/plots/all_1901.png">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚾</text></svg>">
   <script src="https://unpkg.com/@panzoom/panzoom@4.5.1/dist/panzoom.min.js"></script>
   <style>
@@ -247,12 +253,23 @@
       text-decoration: none;
     }
     footer a:hover { text-decoration: underline; }
+    .mobile-warning {
+      display: none;
+      background: #f5c518;
+      color: #1a1a2e;
+      text-align: center;
+      padding: 10px 20px;
+      font-weight: 700;
+      font-size: 14px;
+    }
+    @media (max-width: 720px) {
+      .mobile-warning { display: block; }
+    }
   </style>
 </head>
 <body>
-  <div class="nav" style="max-width:1600px;">
-    <div><a href="index.html">← Home</a> · <a href="about.html">About</a></div>
-    <div><a href="team_breakdown.html">Team Breakdown →</a></div>
+  <div class="mobile-warning">⚠️ Built for large displays. Best viewed on desktop.</div>
+  <div class="nav" style="max-width:2400px;">
   </div>
 
   <h1>⚾ MLB Franchise WAR Explorer</h1>


### PR DESCRIPTION
## Summary

Three small polish items across all HTML pages.

### Open Graph meta tags
All 4 pages (`index`, `war_explorer`, `team_breakdown`, `about`) now include:
- `og:title`, `og:description`, `og:type`, `og:url`, `og:image`
- `twitter:card = summary_large_image`

When someone shares a link on Slack/Twitter/etc, it'll show a title, description, and the 30-team grid as the preview image.

### Mobile warning banner
Added a yellow warning banner to `war_explorer.html` and `team_breakdown.html`:
> ⚠️ Built for large displays. Best viewed on desktop.

Only shows on viewports ≤720px (hidden otherwise). `index.html` already had this.

### Nav bar width fix
Nav bar on both viewer pages was still at `max-width: 1600px` from before the 2400px viewer widening. Updated to match.