### PR TITLE
Fix MIL franchise mapping + per-franchise DH assignment

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -220,8 +220,10 @@
       <p>
         Each player is assigned a single primary position based on where they played the
         most career games. Outfield positions (LF, CF, RF) are consolidated into OF.
-        Pitchers are classified as SP or RP based on whether career games started exceed
-        50% of total games. Two-way players like Ohtani are assigned one position — there
+        Pitchers are classified as SP or RP based on whether games started exceed
+        50% of total games <em>for that franchise</em>. In team breakdowns, DH is assigned
+        per-franchise (a player must have more DH than fielding games with that specific team).
+        Two-way players like Ohtani are assigned one position — there
         is no special handling to capture contributions at multiple positions.
       </p>
       <p>
@@ -235,6 +237,9 @@
       <p>Known issues and possible quibbles:</p>
       <ul style="margin: 8px 0 0 24px; color: #c0c0d0; line-height: 1.7;">
         <li>Position categorization is somewhat fraught — we assign each player to the position where they logged the most career games.</li>
+        <li>NL teams show a DH facet in the team breakdown. This reflects interleague play (1997–2019),
+            the COVID-era universal DH (2020), and the permanent universal DH (2022–present). Pre-2022
+            DH data for NL teams is sparse by nature.</li>
         <li>The z-score comparison pool uses year-specific position qualification (not career), with
             minimum games thresholds and a 3-year rolling average for the positional mean. Pools with
             fewer than 8 qualified players use a variance floor. Despite this, z-scores for

--- a/franchise_war_functions.R
+++ b/franchise_war_functions.R
@@ -53,7 +53,7 @@ franchise_map <- function(team_id, year_id = NA) {
     # NL Central
     team_id %in% c("CHC", "CHN") ~ "CHC",
     team_id == "CIN" ~ "CIN",
-    team_id %in% c("MIL", "SEP") ~ "MIL",
+    team_id %in% c("MIL", "SEP") & (team_id == "SEP" | year_id >= 1970) ~ "MIL",
     team_id == "PIT" ~ "PIT",
     team_id %in% c("STL", "SLN") ~ "STL",
     

--- a/team_position_breakdown.R
+++ b/team_position_breakdown.R
@@ -36,16 +36,19 @@ generate_team_position_plot <- function(
     team_name <- team_code
   }
   
-  # Get primary position including DH from Appearances
-  # DH is based on most games at DH vs other positions
+  # Get primary DH classification PER FRANCHISE from Lahman Appearances
+  # A player is DH for this franchise only if they played more DH than
+  # field games specifically for this team (not career-wide)
   dh_players <- Lahman::Appearances %>%
+    mutate(franchise = franchise_map(teamID, yearID)) %>%
+    filter(franchise == team_code) %>%
     group_by(playerID) %>%
     summarise(
       dh_games = sum(G_dh, na.rm = TRUE),
       field_games = sum(G_defense, na.rm = TRUE),
       .groups = "drop"
     ) %>%
-    filter(dh_games > field_games * 0.5) %>%  # Primarily DH if >50% DH
+    filter(dh_games > field_games * 0.5) %>%
     select(playerID, is_primary_dh = dh_games) %>%
     mutate(is_primary_dh = TRUE)
   


### PR DESCRIPTION
## Summary

Two data correctness fixes for team breakdowns, plus a documentation update.

### 1. MIL franchise mapping (1884/1891 ghost teams)
BR's WAR data has `team_ID='MIL'` for three different clubs:
- 1884 Milwaukee Brewers (Union Association — defunct)
- 1891 Milwaukee Brewers (American Association — defunct)
- 1970+ Milwaukee Brewers (current franchise, née Seattle Pilots)

The franchise map had no year guard, so the 1884 and 1891 players were incorrectly attributed to the current Brewers, making the team breakdown start in the 1880s.

**Fix**: Add `year_id >= 1970` guard on the MIL mapping.

### 2. DH position assignment (per-franchise, not career-wide)
The DH classification used **career-wide** Appearances data. Players like Jim Thome (1B for PHI), Oscar Gamble (OF for PHI), and Mike Easler were incorrectly shown in the DH facet for franchises where they never played DH — because they accumulated enough DH games with *other* teams.

11 players were wrongly assigned DH for PHI alone.

**Fix**: Filter Appearances to the specific franchise before computing DH-vs-field ratio, matching the per-franchise pattern already used for SP/RP classification. Edgar Martinez still correctly assigned DH for SEA.

### 3. NL DH caveat in about.html
Added a note explaining why NL teams show a DH facet (interleague play 1997–2019, COVID universal DH 2020, permanent universal DH 2022+). Updated the position methodology description to reflect per-franchise assignment.

### After merge
PNGs will need regeneration for all teams affected by these fixes.